### PR TITLE
docs: add agent context maps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# Agent Onboarding
+
+This repository contains the running production DataRun mobile/data-collection app and the local SDK package it consumes.
+
+Before changing code, read:
+
+- `docs/agent-context/agents-onboarding.md`
+- `docs/agent-context/05-classification-reconciliation.md`
+- the focused map for the area you are touching, especially `02-form-flow.md`, `03-config-fetching.md`, `04-state-di-runtime-map.md`, `06-large-repeat-hang-data-loss.md`, and `07-repeat-uid-contract.md`.
+
+Core rules:
+
+- Treat docs, comments, table names, generated files, and old code as evidence, not authority.
+- Classify code as ACTIVE only when removing it without replacement would break startup/auth/navigation, sync/offline cache, assignment/form access, form load/render/repeat/edit/save, or submission table behavior.
+- Prefer active runtime entrypoints, imports, route registrations, DI registrations actually used, and call paths over names that sound relevant.
+- Keep code changes small, reversible, and scoped to one behavior.
+- Do not mix tooling, docs, save correctness, repeat UID behavior, and performance refactors in one PR.
+- Do not base form persistence changes on inactive-looking `repeat_instances`, `data_values`, or old form-state/provider paths unless runtime evidence proves they are active.
+
+Known high-risk form areas:
+
+- active form state is scoped `GetIt` `FormInstance` plus `reactive_forms`, not the old commented Riverpod form providers.
+- form loading builds the full form JSON, full control tree, and full element tree eagerly.
+- submissions are saved as one whole `formData` JSON object.
+- large repeats, expressions, field subscriptions, and repeat UID persistence are known risk areas.
+
+Common commands:
+
+```bash
+flutter pub get
+flutter run
+flutter build apk --debug
+flutter analyze
+flutter test
+dart run build_runner build --delete-conflicting-outputs
+```
+
+Definition of done for code changes:
+
+- Active path identified and inactive lookalikes ruled out.
+- Smallest practical PR slice chosen.
+- Relevant generated files handled intentionally.
+- Build/checks run or explicitly reported as not run.
+- User-facing behavior, persistence, sync, and migration risk called out.

--- a/docs/agent-context/01-production-code-path-map.md
+++ b/docs/agent-context/01-production-code-path-map.md
@@ -1,0 +1,356 @@
+# Production Code Path Map
+
+Generated: 2026-07-10
+
+Scope: map active production paths before refactoring. This treats docs, names, comments, and stale-looking code as evidence only. Classifications below are based on live imports, route registration, DI registration, and call sites found in this scan.
+
+Status legend:
+
+- Active: reachable through current app entrypoints, DI, imports, routes, or direct call sites.
+- Inactive: present but not found in current call paths.
+- Uncertain: has some references, but production reachability was not proven.
+- Obsolete-looking: mostly commented, generated-but-unused, or superseded by another active path.
+
+## 1. Main app entrypoints
+
+Active:
+
+- `android/app/src/main/kotlin/org/datarun/app/MainActivity.kt:5` is the Android native shell entrypoint and extends `FlutterActivity`.
+- `lib/main.dart:25` defines `main()`.
+- `lib/main.dart:28` wraps app startup in `SentryFlutter.init`.
+- `lib/main.dart:70` calls `configureDependencies()`.
+- `lib/main.dart:93` runs the app inside `ProviderScope`.
+- `lib/main.dart:101` defines `App extends ConsumerWidget`.
+- `lib/main.dart:174` uses `StackedRouter().onGenerateRoute`.
+- `lib/main.dart:180` sets `Routes.splashView` as the initial route.
+- `lib/app/stacked/app.dart:19-29` registers current Stacked routes: `HomeWrapperPage`, `LoginView`, `SplashView`, `SettingsView`, `SyncResourcesView`, `AssignmentScreen`, `EditRowScreen`, `FormSubmissionScreen`, `FormFlowBootstrapper`, and `TableScreen`.
+- `lib/features/startup/presentation/splash_viewmodel.dart:20-25` routes authenticated users to sync or home, and unauthenticated users to login.
+- `lib/features/home/presentation/home_wrapper_page.dart:19` shows `ActivityListView` as the home body.
+- `lib/features/activity/presentation/activity_list_view.dart:38` opens `AssignmentScreen` from an activity card.
+
+Obsolete-looking or inactive:
+
+- `lib/app/app_routes/*` contains older/commented route code. Current `MaterialApp` uses the Stacked router in `lib/main.dart:174`, not those old route files.
+- `lib/app/stacked/app.router.dart` is active generated route code, but should not be edited manually.
+
+## 2. SDK entrypoints and app consumption
+
+Active:
+
+- `pubspec.yaml:17-18` consumes `d_sdk` as a local path dependency: `./packages/drun_sdk`.
+- `lib/app/di/injection.dart:18-32` configures app dependencies, then calls `setupSdkLocator()`.
+- `packages/drun_sdk/lib/di/injection.dart:23` initializes SDK GetIt registrations.
+- `lib/core/auth/auth_manager.dart:144-163` creates the per-user app scope, opens the SDK Drift database, registers `AppDatabase`, registers `DbManager`, then calls `registerUserSdkDeps(appLocator)`.
+- `packages/drun_sdk/lib/di/init_active_session_scope.dart:33-60` registers active SDK data sources for the user session. Registered resources include projects, activities, org units, option sets, data elements, form templates, teams, user form access, assignments, and data submissions.
+- `packages/drun_sdk/lib/d_sdk.dart:9` exposes the `DSdk` facade over `DbManager`; app code uses `DSdk.db` and DAO accessors in form and submission flows.
+- `packages/drun_sdk/lib/database/db_factory/database_factory.dart` and `packages/drun_sdk/lib/database/db_factory/platform_app.dart` open per-user Drift database files.
+
+Uncertain:
+
+- `packages/drun_sdk/lib/di/injection.config.dart:69` defines `initActiveSessionContextScope`, but this scan only found app calls to `registerUserSdkDeps` and `setupSdkLocator`.
+
+Obsolete-looking:
+
+- `packages/drun_sdk/lib/datasource/remote_data_sources/form_template_version_datasource.dart:6-7` has inactive/commented Injectable annotations. Form versions are loaded by `DataFormTemplateDatasource` instead.
+
+## 3. Active form-loading path
+
+Active high-level path:
+
+1. A user opens or creates a submission from a table or assignment detail.
+2. Navigation goes to `FormFlowBootstrapper`.
+3. The bootstrapper creates or loads a `DataInstance`.
+4. It loads the form template/version JSON from local Drift tables.
+5. It builds a full in-memory `FormGroup` and full `FormElementInstance` tree.
+6. It registers `FormTemplateRepository` and `FormInstance` in a GetIt scope named by submission id.
+7. It replaces the route with `FormSubmissionScreen`.
+
+Active evidence:
+
+- `lib/features/data_instance/presentation/table_screen.dart:93` creates a new submission by navigating to `FormFlowBootstrapper`.
+- `lib/features/data_instance/presentation/table_widget.dart:62` edits an existing item by navigating to `FormFlowBootstrapper` with `submissionId`, `formId`, `versionId`, and `assignmentId`.
+- `lib/features/assignment_detail/presentation/details_submissions_table.dart:201` also edits by navigating to `FormFlowBootstrapper`.
+- `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart:47` creates a draft via `_db.dataInstancesDao.createDraft(...)` when `submissionId == null`.
+- `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart:60-68` pushes a GetIt scope for the submission and registers `FormTemplateRepository` plus `FormInstance`.
+- `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart:65` loads template data through `FormTemplateRepository.create(versionUid: dataInstance.templateVersion)`.
+- `lib/data/form_template_repository.dart:21-27` loads `FormTemplateModel`, options, and option sets.
+- `lib/data/form_template_list_service.dart:154` fetches form templates through `formTemplateVersionsDao.selectFormTemplatesWithRefs(...)`.
+- `lib/data/form_template_list_service.dart:166-197` loads a specific/latest `FormTemplateVersion` with `fields`, `sections`, and merged options.
+- `packages/drun_sdk/lib/database/tables/form_template_versions.table.dart:11-17` stores `fields`, `sections`, and `options` as converted text columns. This is the active "form JSON all at once" source.
+- `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart:103` builds the full `FormGroup`.
+- `lib/core/form/builder/form_element_control_builder.dart:51` creates repeat sections as full `FormArray` instances from the entire initial repeat list.
+- `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart:107` builds all form element instances.
+- `lib/core/form/builder/form_element_builder.dart:79` builds a `RepeatSection` with all initial repeat rows.
+- `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart:72` routes into `FormSubmissionScreen`.
+
+Active sync source for template JSON:
+
+- `packages/drun_sdk/lib/datasource/remote_data_sources/form_template_datasource.dart:9-10` registers `DataFormTemplateDatasource`.
+- `packages/drun_sdk/lib/datasource/remote_data_sources/form_template_datasource.dart:18-21` extracts form version rows as extra entities.
+- `packages/drun_sdk/lib/datasource/remote_data_sources/form_template_datasource.dart:35-49` fetches `formTemplateVersions?paged=false` and maps them into `FormTemplateVersion`.
+- `packages/drun_sdk/lib/datasource/base_datasource.dart` performs fetch, map, and batch upsert for active SDK sync resources.
+
+## 4. Active submission-save path
+
+Active:
+
+- `lib/features/form_submission/presentation/form_submission_screen.widget.dart:211` calls `appLocator<FormInstance>().saveFormData()` from the save action.
+- `lib/features/form_submission/application/element/form_instance.dart:85-103` is the active whole-submission save method.
+- `lib/features/form_submission/application/element/form_instance.dart:87` reads the current `DataInstance`.
+- `lib/features/form_submission/application/element/form_instance.dart:88` reduces `formSection.value` into a full nested map.
+- `lib/features/form_submission/application/element/form_instance.dart:97-100` merges the full form value into `formSubmission.formData`.
+- `lib/features/form_submission/application/element/form_instance.dart:103` writes through `_db.dataInstancesDao.updateData(...)`.
+- `packages/drun_sdk/lib/database/dao/data_submissions_dao.dart:198-207` overwrites `formData`, sets sync state to draft, and updates timestamps.
+- `packages/drun_sdk/lib/database/tables/data_submissions.table.dart:39-40` stores `formData` as a nullable JSON text column through `NullAwareMapConverter`.
+- `packages/drun_sdk/lib/database/converters/null_aware_map.converter.dart:6-18` converts the whole map to/from JSON.
+- `lib/features/form_submission/application/element/form_instance.dart:177` marks a submission final through `dataInstancesDao.markFinal`.
+- `packages/drun_sdk/lib/database/dao/data_submissions_dao.dart:210-218` marks final by changing sync state and timestamps, not by normalizing form values.
+
+Inactive or obsolete-looking:
+
+- `lib/features/form_submission/application/repository/submission_capture_repository_impl.dart` is fully commented and references old DHIS/D2 style APIs.
+- `lib/features/form_submission/application/form_instance.provider.dart` is fully commented; the active `FormInstance` is now registered in GetIt scope by the bootstrapper.
+
+## 5. Active repeat-rendering/editing path
+
+Active render path:
+
+- `lib/features/form_submission/presentation/form_entry_view_silver.widget.dart` renders root elements from `appLocator<FormInstance>()`.
+- `lib/features/form_submission/presentation/section/section.widget.dart` recursively renders nested `Section`, `RepeatSection`, and `FieldInstance`.
+- `lib/features/form_submission/presentation/section/repeat_table_sliver.dart` wraps a `RepeatTable` in a sliver/sticky header.
+- `lib/features/form_submission/presentation/section/repeat_table.widget.dart:17` defines active `RepeatTable`.
+- `lib/features/form_submission/presentation/section/repeat_table.widget.dart:108` uses `PaginatedDataTable`.
+- `lib/features/form_submission/presentation/section/repeat_table_rows_source.dart` provides rows from in-memory `RepeatItemInstance` objects.
+
+Active add/edit/delete path:
+
+- `lib/features/form_submission/application/element/form_instance.dart:134-149` adds a repeated row by creating a child `FormGroup`, adding it to the parent `FormArray`, building a `RepeatItemInstance`, resolving dependencies, and evaluating the row.
+- `lib/features/form_submission/application/element/form_instance.dart:153-157` removes a repeated row from both the element list and the `FormArray`.
+- `lib/features/form_submission/presentation/section/repeat_table.widget.dart:116` calls `formInstance.onAddRepeatedItem(...)`.
+- `lib/features/form_submission/presentation/section/repeat_table.widget.dart:60` calls `formInstance.onRemoveRepeatedItem(...)`.
+- `lib/features/form_submission/presentation/section/repeat_table.widget.dart:181-191` opens `EditRowScreen` via `NavigationService.navigateToView(...)`.
+- `lib/features/form_submission/presentation/section/repeat_table.widget.dart:200` saves the whole submission after a repeat row save.
+- `lib/features/form_submission/presentation/section/repeat_table.widget.dart:264` does the same from the dialog/panel path.
+- `lib/features/form_submission/presentation/section/edit_row_screen.dart:17` defines the row editing screen.
+- `lib/features/form_submission/presentation/section/edit_row_screen.dart:114` wraps the row controls in `ReactiveForm`.
+
+Uncertain:
+
+- `lib/app/stacked/app.dart:25` registers `EditRowScreen` as a Stacked route, and generated route code exists. The active repeat table call site uses `navigateToView(...)`, not the generated `navigateToEditRowScreen(...)` helper.
+
+Important active repeat data detail:
+
+- `lib/features/form_submission/application/element/repeat_item_instance.dart:24-32` has a row uid field, but `reduceValue()` has the `repeatUid` write commented out. The saved form JSON appears to identify repeat rows by list position, not stable row id.
+
+## 6. State management libraries found
+
+Active:
+
+- Riverpod/Hooks:
+  - `lib/main.dart:93` wraps the app in `ProviderScope`.
+  - `lib/main.dart:101` uses `ConsumerWidget`.
+  - Active providers include `preferenceProvider`, `authProvider`, `dataInstanceFilterProvider`, `totalItemsStreamProvider`, `selectedItemsProvider`, `submissionEditStatusProvider`, and form/template display providers.
+  - Active screens/widgets include `HookConsumerWidget`, `StatefulHookConsumerWidget`, and `ConsumerStatefulWidget` under form and table UI.
+- Stacked:
+  - `lib/app/stacked/app.dart:19-29` defines Stacked routes.
+  - `lib/features/startup/presentation/splash_view.dart` and `lib/features/form_submission/presentation/form_flow_bootstrapper.dart` are `StackedView`s.
+  - `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart:21` uses `BaseViewModel`.
+  - `lib/features/sync/presentation/sync_resources_viewmodel.dart:13` uses `StreamViewModel`.
+- GetIt/Stacked locator:
+  - `lib/app/di/injection.dart` sets `appLocator`.
+  - `lib/core/auth/auth_manager.dart:144-163` manages per-user database scope.
+  - `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart:60-68` manages per-submission scope.
+  - Active form widgets repeatedly read `appLocator<FormInstance>()`.
+- Reactive Forms:
+  - `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart:103` creates the root `FormGroup`.
+  - `lib/core/form/builder/form_element_control_builder.dart:51` creates repeat `FormArray`s.
+  - Field widgets and row edit screens use `ReactiveForm` and `ReactiveFormField`.
+- RxDart/streams:
+  - `lib/features/form_submission/application/element/form_element.dart:42-47` uses `BehaviorSubject` for element property changes.
+  - `lib/features/form_submission/application/element/repeat_instance.dart:14-17` uses `BehaviorSubject` for repeat collection changes.
+
+Inactive or obsolete-looking:
+
+- `lib/features/form_submission/application/form_instance.provider.dart` and `lib/features/form_submission/application/element/form_element_instance.provider.dart` are commented Riverpod form-instance experiments.
+- `lib/core/element_instance/form_state.provider.dart` and `lib/core/form/form_state/form_state.provider.dart` are commented/incomplete alternate form state approaches.
+- Several `StateProvider`/`StateNotifier` form-state files under `lib/features/form/application/form/form_state/` look experimental or commented.
+
+## 7. Form-related DB tables/code paths that appear inactive or incomplete
+
+Active:
+
+- `data_instances`: active submission table. Evidence: `DataInstancesDao.createDraft`, `updateData`, `markFinal`, list queries, and sync upload.
+- `form_templates` and `form_template_versions`: active form metadata/template source. Evidence: `DataFormTemplateDatasource`, `FormTemplateListService`, `FormTemplateRepository`.
+- `data_elements`: active metadata/value display support and active sync resource. Evidence: `DataElementDatasource` is registered; display logic resolves data element metadata.
+- `data_options` and `data_option_sets`: active option display and form option merging.
+
+Inactive or incomplete-looking:
+
+- `repeat_instances`:
+  - Table and DAO exist: `packages/drun_sdk/lib/database/app_database.dart:23,50`, `packages/drun_sdk/lib/database/tables/repeat_instances.table.dart:6`.
+  - App repeat rendering/editing does not use the table; repeats are stored inside `DataInstance.formData` as nested JSON lists.
+  - `packages/drun_sdk/lib/datasource/remote_data_sources/repeat_instance_datasource.dart:6-8` has commented `@Order` and `@Injectable`.
+  - `packages/drun_sdk/lib/datasource/remote_datasource_order_map.dart:43` comments out `repeatInstance`.
+  - Classification: inactive/incomplete-looking for current capture flow.
+- `data_values`:
+  - Table and DAO exist: `packages/drun_sdk/lib/database/app_database.dart:24,49`, `packages/drun_sdk/lib/database/tables/data_values.table.dart:4`.
+  - Active capture save does not write `data_values`; it writes `data_instances.formData`.
+  - `lib/core/element_instance/data_value_repository.dart` can read/write `db.dataValues`, but current form capture does not call it.
+  - `packages/drun_sdk/lib/datasource/remote_data_sources/data_value_datasource.dart:6-8` has commented `@Order` and `@Injectable`, and it is not registered in `registerUserSdkDeps`.
+  - Classification: not active for capture/save; partially active for display/value mapping support through `DataValueRepository`.
+- `metadata_submissions`:
+  - `packages/drun_sdk/lib/database/tables/metadata_submissions.table.dart:6` is commented out.
+  - `packages/drun_sdk/lib/database/tables/tables.dart` exports it, but `AppDatabase` does not include an active `MetadataSubmissions` table.
+  - `lib/data/metadata_submission_update.provider.dart:13` has the old DB query commented out and currently returns `[]`.
+  - `packages/drun_sdk/lib/datasource/remote_data_sources/metadata_submission_datasource.dart` is fully commented.
+  - Classification: obsolete-looking/incomplete.
+- `FormTemplateVersionDatasource`:
+  - Present but inactive-looking because its Injectable annotations are commented and versions are loaded via `DataFormTemplateDatasource.extractExtraEntities`.
+
+## 8. Candidate duplicated services/functions
+
+Observations only:
+
+- Template tree construction appears duplicated:
+  - `packages/drun_sdk/lib/database/shared/form_template_model.dart:22,33` builds a tree in `FormTemplateModel`.
+  - `lib/data/form_template_repository.dart:53,101` builds another tree/cache for runtime rendering.
+- Form instance construction appears duplicated:
+  - Active: `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart:103-127`.
+  - Commented old Riverpod path: `lib/features/form_submission/application/form_instance.provider.dart:21-90`.
+- Template services overlap:
+  - Active list/detail service: `lib/data/form_template_list_service.dart`.
+  - Active DI service: `lib/features/form/application/form_template_service_impl.dart`.
+  - Old/commented service: `lib/data/form_template_service.dart`.
+- Submission table/query responsibilities overlap:
+  - `lib/features/form_submission/application/form_instance_service_impl.dart` fetches/counts paginated submissions through `DataInstancesDao.selectable/countSubmissions`.
+  - `lib/features/data_instance/data/drift_table_repository.dart` also builds table queries and counts through `DataInstancesDao.getFilterQuery`.
+  - `packages/drun_sdk/lib/database/dao/data_submissions_dao.dart` has both `selectSubmissions` and `selectable`, plus count methods.
+- Submission list state overlaps:
+  - `lib/features/form_submission/application/submission_list.provider.dart` manages form submissions and update/sync operations.
+  - `lib/features/data_instance/application/table.providers.dart` and `table_controller.provider.dart` manage current table filters, selection, delete, and sync.
+- Repeat row UI has both screen and dialog/panel paths:
+  - `EditRowScreen` is active.
+  - `EditRowPanel` and `showEditDialog` are still present; `showEditPanel` currently uses `EditRowScreen` inside `navigateToView`.
+- Value/display mapping has multiple layers:
+  - `MapValueToDisplay`, `ValueTypeValueDisplay`, `SubmissionTableCell`, `DataValueRepository`, and field-level user-friendly value helpers overlap in responsibility.
+
+## 9. Risk map for large forms with 200-300 repeat rows
+
+High risk:
+
+- Full upfront form construction:
+  - `FormElementControlBuilder.formDataControls` and `createRepeatFormArray` build controls for every repeat row.
+  - `FormElementBuilder.buildRepeatInstance` builds `RepeatItemInstance` objects for every repeat row.
+  - `Section.resolveDependencies()` and `Section.evaluate()` traverse the full tree at bootstrap.
+  - Impact: startup/render latency and memory grow with repeat rows multiplied by fields per row.
+- Whole-submission save:
+  - `FormInstance.saveFormData()` reduces `formSection.value` for the whole tree, merges it, and writes the entire JSON column.
+  - Repeat row save calls `formInstance.saveFormData()` immediately.
+  - Impact: editing one row can serialize and write all 200-300 rows.
+- Whole JSON column storage:
+  - `data_instances.formData` is one JSON text column. Large repeat lists make SQLite writes, JSON encode/decode, sync payloads, and conflict handling larger.
+- Stream/subscription pressure:
+  - Each element has a `BehaviorSubject`.
+  - `FieldWidget` subscribes to `control.valueChanges`; the cleanup currently returns a function that returns the subscription object, not a call to cancel it. That should be verified before changing anything.
+
+Medium risk:
+
+- Repeat table UI:
+  - `PaginatedDataTable` displays pages, but `RepeatTableDataSource` still holds all row instances in memory.
+  - Wide repeat sections render one column per immediate child field, which can create very wide tables.
+- Dependency evaluation:
+  - Dependency resolution walks parent sections and can fall back to walking the full tree.
+  - Rule evaluation notifies dependents on value/status changes.
+  - Impact depends on number of calculated/visibility/filter dependencies inside repeat rows.
+- Row identity:
+  - `RepeatItemInstance.uid` exists, but `repeatUid` persistence is commented out in `reduceValue()`.
+  - Impact: row identity is index/list-position based unless something else preserves identity outside this path.
+- Scope lifetime:
+  - The active form is a GetIt scope keyed by submission id. Back/save flows drop scopes in several places.
+  - Impact: multiple open form routes or unusual navigation could leave stale `FormInstance`/registry state if scope transitions are wrong.
+
+Uncertain risk:
+
+- Background DB connection helps database IO, but JSON map reduction and serialization appear to happen in app code before/around the DAO call. Runtime profiling is needed to confirm UI-thread cost.
+- `RepeatTableDataSource.updateItems` uses a predicate that appears self-comparing. It should be inspected before relying on table refresh behavior for large repeat edits.
+
+## 10. Do not touch until understood
+
+Treat these as high-risk files until the active paths above are fully understood:
+
+- `lib/main.dart`
+- `lib/app/di/injection.dart`
+- `lib/app/stacked/app.dart`
+- `lib/app/stacked/app.router.dart` (generated; do not edit directly)
+- `lib/core/auth/auth_manager.dart`
+- `packages/drun_sdk/lib/di/injection.dart`
+- `packages/drun_sdk/lib/di/init_active_session_scope.dart`
+- `packages/drun_sdk/lib/database/app_database.dart`
+- `packages/drun_sdk/lib/database/dao/data_submissions_dao.dart`
+- `packages/drun_sdk/lib/database/tables/data_submissions.table.dart`
+- `packages/drun_sdk/lib/database/converters/null_aware_map.converter.dart`
+- `packages/drun_sdk/lib/datasource/base_datasource.dart`
+- `packages/drun_sdk/lib/datasource/remote_data_sources/form_template_datasource.dart`
+- `packages/drun_sdk/lib/datasource/remote_datasource_order_map.dart`
+- `lib/data/form_template_repository.dart`
+- `lib/data/form_template_list_service.dart`
+- `lib/core/form/builder/form_element_control_builder.dart`
+- `lib/core/form/builder/form_element_builder.dart`
+- `lib/features/form_submission/presentation/form_flow_bootstrapper.dart`
+- `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart`
+- `lib/features/form_submission/presentation/form_submission_screen.widget.dart`
+- `lib/features/form_submission/application/element/form_instance.dart`
+- `lib/features/form_submission/application/element/form_element.dart`
+- `lib/features/form_submission/application/element/section_instance.dart`
+- `lib/features/form_submission/application/element/repeat_instance.dart`
+- `lib/features/form_submission/application/element/repeat_item_instance.dart`
+- `lib/features/form_submission/presentation/form_entry_view_silver.widget.dart`
+- `lib/features/form_submission/presentation/section/section.widget.dart`
+- `lib/features/form_submission/presentation/section/repeat_table_sliver.dart`
+- `lib/features/form_submission/presentation/section/repeat_table.widget.dart`
+- `lib/features/form_submission/presentation/section/repeat_table_rows_source.dart`
+- `lib/features/form_submission/presentation/section/edit_row_screen.dart`
+- `lib/features/form_submission/presentation/field/field.widget.dart`
+- `lib/features/form_submission/application/submission_list.provider.dart`
+- `lib/features/data_instance/application/table.providers.dart`
+- `lib/features/data_instance/application/table_controller.provider.dart`
+- `lib/features/data_instance/presentation/table_screen.dart`
+- `lib/features/data_instance/presentation/table_widget.dart`
+- `lib/features/data_instance/data/drift_table_repository.dart`
+- `lib/features/data_instance/data/table_repository.dart`
+
+Also do not delete these until their old/partial roles are explicitly resolved:
+
+- `lib/features/form_submission/application/form_instance.provider.dart`
+- `lib/features/form_submission/application/element/form_element_instance.provider.dart`
+- `lib/core/element_instance/form_state.provider.dart`
+- `lib/core/form/form_state/form_state.provider.dart`
+- `lib/core/element_instance/data_value_repository.dart`
+- `packages/drun_sdk/lib/database/tables/data_values.table.dart`
+- `packages/drun_sdk/lib/database/tables/repeat_instances.table.dart`
+- `packages/drun_sdk/lib/database/tables/metadata_submissions.table.dart`
+- `packages/drun_sdk/lib/datasource/remote_data_sources/data_value_datasource.dart`
+- `packages/drun_sdk/lib/datasource/remote_data_sources/repeat_instance_datasource.dart`
+- `packages/drun_sdk/lib/datasource/remote_data_sources/metadata_submission_datasource.dart`
+
+## Suggested next investigation step
+
+Run a focused runtime trace on one real example form with a large repeat section:
+
+1. Seed or load a submission with 200-300 repeat rows from `example/`.
+2. Instrument only timings and sizes around:
+   - `FormFlowBootstrapperVm.bootstrapFlow`
+   - `FormElementControlBuilder.formDataControls`
+   - `FormElementBuilder.buildFormElements`
+   - `Section.resolveDependencies`
+   - `Section.evaluate`
+   - `FormInstance.saveFormData`
+   - `DataInstancesDao.updateData`
+3. Record:
+   - build time
+   - row edit save time
+   - JSON payload size
+   - widget rebuild count if possible
+   - memory before/after opening and closing the form
+
+Do this before refactoring or introducing normalized repeat/data-value storage.

--- a/docs/agent-context/02-form-flow.md
+++ b/docs/agent-context/02-form-flow.md
@@ -1,0 +1,230 @@
+# Form Flow Code Map
+
+Generated: 2026-07-10
+
+Scope: evidence-based map for form JSON loading, form rendering, repeats, expression evaluation touching repeats, submission save/edit, repeat UID behavior, and local persistence before sync. This complements `01-production-code-path-map.md`; it intentionally does not remap the whole app entrypoint and SDK entrypoint surface.
+
+Read mode: production source was scanned only. This document is the only new output.
+
+Status legend:
+
+- ACTIVE: used by reachable production runtime flow.
+- INACTIVE: not referenced by active runtime flow found in this scan.
+- INCOMPLETE: looks like unfinished feature work.
+- LEGACY-RISK: old code that might still be called indirectly or reused accidentally.
+- UNKNOWN: cannot prove either way from static references.
+
+## Active Form Flow
+
+| Area | Classification | File path | Evidence | Confidence | Why it matters for large repeats or repeat UIDs |
+| --- | --- | --- | --- | --- | --- |
+| Form route registration | ACTIVE | `lib/app/stacked/app.dart` | `MaterialRoute(page: EditRowScreen)`, `FormSubmissionScreen`, and `FormFlowBootstrapper` are registered at lines 25-27. Generated navigation exists in `lib/app/stacked/app.router.dart:103-111`, `599-667`, and `823-863`. | High | Repeat editing is route-backed. Any repeat edit performance issue can involve route creation, modal navigation, and generated Stacked route behavior. |
+| Create/edit navigation from table | ACTIVE | `lib/features/data_instance/presentation/table_screen.dart` | New submission action calls `navigateToFormFlowBootstrapper` at line 93. | High | This is the active create path into form loading. Large repeat defaults would be loaded from this path if a draft already has form data. |
+| Edit navigation from table rows | ACTIVE | `lib/features/data_instance/presentation/table_widget.dart` | Existing row edit calls `navigateToFormFlowBootstrapper` with `submissionId`, `formId`, `versionId`, and `assignmentId` at line 62. | High | This is a direct server/draft edit path into repeat rendering. It determines whether existing `formData` rows get rebuilt. |
+| Edit navigation from assignment detail | ACTIVE | `lib/features/assignment_detail/presentation/details_submissions_table.dart` | Existing submission rows navigate to `FormFlowBootstrapper` at line 201. | High | This is another active edit entrypoint for synced or draft records. |
+| Assignment detail create path | ACTIVE | `lib/features/assignment_detail/presentation/assignment_detail_page.dart` | Calls `navigateToFormFlowBootstrapper` at line 140. | High | Confirms active production flow can create submissions without going through only the data instance table screen. |
+| Bootstrapper view | ACTIVE | `lib/features/form_submission/presentation/form_flow_bootstrapper.dart` | Stacked view creates `FormFlowBootstrapperVm` at lines 73-80 and calls `bootstrapFlow(submissionId)` at line 83. | High | The bootstrapper is the hard boundary where the form instance scope is created. |
+| Draft/load bootstrap logic | ACTIVE | `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart` | `createDraft` is called for new submissions at line 47; existing submissions are loaded with `_db.dataInstances.findById(submissionId).getSingle()` at line 54. | High | Existing server-submitted records and local drafts converge here before the full form tree is built. |
+| Per-submission DI scope | ACTIVE | `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart` | Pushes a GetIt scope named by `dataInstance.id` at line 60 and registers `FormTemplateRepository`/`FormInstance` at lines 63-68. | High | Repeat state is held in a scoped in-memory `FormInstance`; stale scopes or scope lifetime bugs can affect edit/save behavior. |
+| Template JSON load | ACTIVE | `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart` | Calls `FormTemplateRepository.create(versionUid: dataInstance.templateVersion)` at line 65. | High | The active flow loads one template version as a whole before rendering; no lazy section/repeat load was found. |
+| Form controls build | ACTIVE | `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart` | Creates full `FormGroup` from `FormElementControlBuilder.formDataControls(...)` at line 103. | High | For 200-300 repeat rows, all repeat row controls are allocated up front. |
+| Form element tree build | ACTIVE | `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart` | Calls `FormElementBuilder.buildFormElements(...)` at line 107, wraps it in a root `Section`, then calls `resolveDependencies()` and `evaluate(emitEvent: false)` before navigation. | High | Repeat trees, dependencies, and initial rule evaluation are all eager. |
+| Form template repository | ACTIVE | `lib/data/form_template_repository.dart` | `create` loads template, options, and option sets at lines 18-27; `rootSection` builds a tree from template fields and sections. | High | Template flattening/tree construction is central to repeat path names and dependency lookup. |
+| Template local query service | ACTIVE | `lib/data/form_template_list_service.dart` | `fetchByFilter` uses `formTemplateVersionsDao.selectFormTemplatesWithRefs(...)` at line 154; `getTemplateByVersionOrLatest` loads version data at lines 166-197. | High | This is the active local cache layer for form JSON before rendering. |
+| Template storage table | ACTIVE | `packages/drun_sdk/lib/database/tables/form_template_versions.table.dart` | Stores `fields`, `sections`, and `options` as text columns with converters. | High | Confirms active form definition is stored as JSON-like blobs, not normalized per field table reads at render time. |
+| Template sync datasource | ACTIVE | `packages/drun_sdk/lib/datasource/remote_data_sources/form_template_datasource.dart` | Injectable active datasource at lines 9-10; extracts `formTemplateVersions` at lines 18 and 35-49. | High | This is the sync path that populates the local template version JSON used by forms. |
+| Form screen | ACTIVE | `lib/features/form_submission/presentation/form_submission_screen.widget.dart` | `FormSubmissionScreen` is active at line 23; watches `submissionEditStatusProvider` at lines 48-49; uses `FormInstanceEntryViewSliver` at line 114; save calls `appLocator<FormInstance>().saveFormData()` at line 211; final submit calls `markSubmissionAsFinal()` at line 275. | High | This is the main rendering/save host. It mixes Riverpod edit status with GetIt-held form instance state. |
+| Root rendering sliver | ACTIVE | `lib/features/form_submission/presentation/form_entry_view_silver.widget.dart` | Reads `appLocator<FormInstance>()` and maps root elements to `SectionWidget`, `RepeatTableSliver`, or `FieldWidget` at lines 11-41. | High | Rendering starts by iterating all root elements. Repeats are rendered as tables, not virtualized row forms. |
+| Section rendering | ACTIVE | `lib/features/form_submission/presentation/section/section.widget.dart` | Watches `element.propertiesChanged`; recursively renders `SectionWidget`, `RepeatTableSliver`, and `FieldWidget` at lines 13-85. | High | Hidden/visible rules and repeat nesting trigger rebuilds through `propertiesChanged`. |
+| Field rendering | ACTIVE | `lib/features/form_submission/presentation/field/field.widget.dart` | `FieldWidget` is active at line 12; subscribes to control value changes and renders `FieldFactory.fromType(element)` at line 55. | High | Every field inside every repeat row can attach value-change behavior. Static scan found cleanup code that returns the subscription object rather than clearly cancelling it; runtime confirmation needed. |
+| Field widget factory | ACTIVE | `lib/features/form_submission/application/form_widget_factory.dart` | `FieldFactory` is called by `FieldWidget`; maps field `ValueType` to concrete reactive widgets. | High | Large repeat row cost depends on the number and type of fields created per row. |
+| Repeat controls build | ACTIVE | `lib/core/form/builder/form_element_control_builder.dart` | Repeatable sections create a `FormArray<Map<String,Object?>>`; existing initial rows map through `createSectionFormGroup(...)` at lines 51-58. | High | All initial repeat rows become controls up front. This is a primary performance and memory pressure point. |
+| Repeat element tree build | ACTIVE | `lib/core/form/builder/form_element_builder.dart` | `buildRepeatInstance` maps every initial list row into a `RepeatItemInstance` at lines 79-91; `buildRepeatItem` reads `initialFormValue?['repeatUid']` at line 69. | High | Client/server repeat UID behavior depends on whether `repeatUid` exists in row JSON. |
+| Repeat section model | ACTIVE | `lib/features/form_submission/application/element/repeat_instance.dart` | `RepeatSection` owns `BehaviorSubject<List<RepeatItemInstance>>`, `addAll`, `reduceValue`, `resolveDependencies`, and `evaluate`. | High | Repeat collection changes and rule evaluation are centralized here. Large repeats may emit and evaluate many rows. |
+| Repeat row model | ACTIVE | `lib/features/form_submission/application/element/repeat_item_instance.dart` | Has `_uid`, `uid`, `setUid`, index-based `name`, and `reduceValue`; `map['repeatUid'] = _uid ?? CodeGenerator.generateUid()` is commented out at line 47. | High | Static evidence shows repeat UIDs can be read and set, but are not currently written back by `reduceValue`. This is the central repeat UID risk. |
+| Add/remove repeat rows | ACTIVE | `lib/features/form_submission/application/element/form_instance.dart` | `onAddRepeatedItem` creates a new row control/tree and evaluates it at lines 134-149; `onRemoveRepeatedItem` removes from model and `FormArray` at lines 153-157. | High | Add/remove is index-based. Without persisted repeat UIDs, editing server-submitted rows may not preserve stable row identity. |
+| Repeat table sliver | ACTIVE | `lib/features/form_submission/presentation/section/repeat_table_sliver.dart` | Wraps `RepeatTable` and watches repeat properties. | High | This is the active repeat rendering bridge. |
+| Repeat table | ACTIVE | `lib/features/form_submission/presentation/section/repeat_table.widget.dart` | Initializes `RepeatTableDataSource` at line 69; renders `PaginatedDataTable` at line 108; add calls `onAddRepeatedItem` at line 116; row edit opens `_showEditPanel`; save calls `formInstance.saveFormData()` at line 200. | High | Repeats are displayed through `PaginatedDataTable`, but the data source still holds all rows. Add/save inside row edit writes the whole form JSON. |
+| Repeat row edit screen | ACTIVE | `lib/features/form_submission/presentation/section/edit_row_screen.dart` | Active routed widget; wraps row `ReactiveForm` at line 114; sets repeat UID with `CodeGenerator.generateUid()` around line 184 when saving a new row. | High | UID generation appears to happen in UI save flow, but persistence is uncertain because row `reduceValue` does not write `repeatUid`. |
+| Repeat table data source | ACTIVE | `lib/features/form_submission/presentation/section/repeat_table_rows_source.dart` | Extends `DataTableSource` at line 15; `updateItems` at line 38; `getRow` at line 62 iterates fields for a repeat row. | High | For large repeats, row rendering scans row fields. `updateItems` appears suspicious because its predicate compares `item.elementPath == item.elementPath`; runtime behavior should be verified before changing performance. |
+| Form instance save | ACTIVE | `lib/features/form_submission/application/element/form_instance.dart` | `saveFormData` at line 85 reads existing submission, computes `formSection.value`, preserves metadata keys, and calls `_db.dataInstancesDao.updateData(...)`. | High | Every save writes one whole `formData` map. Repeat changes are not saved as separate row/value records. |
+| Mark final | ACTIVE | `lib/features/form_submission/application/element/form_instance.dart` | `markSubmissionAsFinal` delegates to DAO at line 176. | High | Finalization changes sync eligibility after whole JSON save. |
+| Submission edit status | ACTIVE | `lib/features/form_submission/application/submission_list.provider.dart` | `submissionEditStatusProvider` starts at line 118 and is watched by form screen and edit icons. | Medium | Determines whether synced server submissions can be edited again. There is also bootstrapper-local edit-status logic, so this is duplicated decision logic. |
+| Data instance table | ACTIVE | `packages/drun_sdk/lib/database/tables/data_submissions.table.dart` | `formData` is a single nullable text column mapped through `NullAwareMapConverter` at lines 39-40; `syncState` and `isToUpdate` are also stored. | High | Confirms active submission persistence is whole JSON per submission. |
+| JSON map converter | ACTIVE | `packages/drun_sdk/lib/database/converters/null_aware_map.converter.dart` | Converts maps through JSON encode/decode. | High | Repeat rows are persisted inside one encoded map; partial repeat row persistence is not active here. |
+| Draft creation | ACTIVE | `packages/drun_sdk/lib/database/dao/data_submissions_dao.dart` | `createDraft` starts at line 162, creates a submission id with `CodeGenerator.generateUid()` at line 171, sets `syncState: draft` and `isToUpdate: false`. | High | Submission id generation is separate from repeat row UID generation. |
+| Whole JSON update | ACTIVE | `packages/drun_sdk/lib/database/dao/data_submissions_dao.dart` | `updateData` starts at line 198 and writes `syncState: draft`, `formData`, timestamps, and client update time. | High | Editing a synced record likely rewrites it as draft while keeping existing `isToUpdate`; confirm server update semantics at runtime. |
+| Final sync upload | ACTIVE | `packages/drun_sdk/lib/database/dao/data_submissions_dao.dart` | `upload` starts at line 51; payload is `submissions.map((s) => s.toUpload())` at line 68; success sets `syncState: synced` and `isToUpdate: true` at lines 93-96. | High | Sync sends the whole JSON payload, including repeats as nested data. |
+| Upload payload shape | ACTIVE | `packages/drun_sdk/lib/database/extensions/data_submission.extension.dart` | `toUpload()` includes `formData` directly at line 19 plus submission metadata. | High | No separate repeat row payload was found in active upload path. |
+| Remote submission import | ACTIVE | `packages/drun_sdk/lib/datasource/remote_data_sources/data_submission_datasource.dart` and `packages/drun_sdk/lib/database/dao/data_submissions_dao.dart` | Data submission datasource is active injectable; DAO `fromApiJson` starts at line 29. Base datasource marks remote rows `isToUpdate: true` in `packages/drun_sdk/lib/datasource/base_datasource.dart:204`. | Medium | Server-submitted records arrive as whole `formData`; editing them again depends on preserving nested repeat row identity in that JSON. |
+| Submission table summaries | ACTIVE | `packages/drun_sdk/lib/database/dao/data_submissions_dao.dart` | `selectable` starts at line 562 and extracts display field values with `FormDataUtil.extractTemplateValue(...)` at lines 641-642. | High | Large repeat values can also affect list/table display, because summary extraction walks nested form data. |
+| Summary form data utility | ACTIVE | `packages/drun_sdk/lib/core/data_instance/form_data_util.dart` | `extractTemplateValue` reads nested form data and aggregates values. | High | Repeat-heavy submissions can have display cost before opening the form. |
+| Summary aggregation | ACTIVE | `packages/drun_sdk/lib/core/data_instance/form_data_aggregator.dart` | Used by `FormDataUtil`; contains example/debug main code too. | Medium | Active through summary extraction, but example code in the file is not evidence of runtime behavior. |
+| Rule action evaluation | ACTIVE | `lib/features/form_submission/application/element/form_element.dart` | `elementRuleActions` are derived from template rules at line 61; `evaluate` starts at line 243; `resolveDependencies` starts at line 397. | High | Dependency resolution/evaluation can run for every element in every repeat row. |
+| Dependency lookup in repeats | ACTIVE | `lib/features/form_submission/application/element/element_dependency.extension.dart` | Builds `evalContext` at line 4, normalizes values at line 11, notifies dependents at line 72, and resolves dependency names from parent sections at line 77. | High | Repeat correctness depends on resolving dependencies to the current repeat row/section rather than another row or global field. |
+| Section rule traversal | ACTIVE | `lib/features/form_submission/application/element/section_instance.dart` | `resolveDependencies` and `evaluate` recurse children at lines 49-71. | High | Eager recursive traversal can be costly on large nested repeat forms. |
+| Repeat rule traversal | ACTIVE | `lib/features/form_submission/application/element/repeat_instance.dart` | `resolveDependencies` and `evaluate` recurse each repeat item at lines 52-74. | High | Large repeat rows multiply rule evaluation cost. |
+| Field choice filters | ACTIVE | `lib/features/form_submission/application/element/field_instance.dart` | `filterDependencies` at line 27; `evaluate` calls `choiceFilter!.evaluate(evalContext)` at lines 76-99. | High | Choice filtering inside repeats can reevaluate option visibility per row. |
+| Rule parsing | ACTIVE | `packages/drun_sdk/lib/core/form/rule/rule_parse_extension.dart` | Extracts dependencies, visibility rules, filter dependencies, and calculation dependencies. | High | Determines which fields subscribe to which other fields, including repeat-local dependencies. |
+| Rule expression evaluation | ACTIVE | `packages/drun_sdk/lib/core/form/rule/action.dart` and `choice_filter.dart` | `RuleAction.evaluate` is at line 90; `ChoiceFilter.evaluate` is at line 18. | High | Runtime expression cost increases with dependency graph size and repeat row count. |
+| UID generation helper | ACTIVE | `packages/drun_sdk/lib/core/code_generator.dart` | Used for submission ids and referenced by repeat UID code. | High | Any repeat UID fix must separate submission id behavior from repeat row identity behavior. |
+
+## Inactive, Incomplete, Or Legacy-Risk Form-Looking Files
+
+| Classification | File path | Evidence | Confidence | Why it matters for large repeats or repeat UIDs |
+| --- | --- | --- | --- | --- |
+| INACTIVE | `lib/features/form_submission/application/form_instance.provider.dart` | References to `FormTemplateRepository.create`, `FormElementControlBuilder`, and `FormElementBuilder` are commented; active screen comments out `formInstanceProvider` and uses `appLocator<FormInstance>()`. | High | It mirrors active form construction, so editing it would not affect current repeat performance unless it is reactivated. |
+| INACTIVE | `lib/features/form_submission/application/element/form_element_instance.provider.dart` | Provider code is commented; only static references found were comments. | High | Looks like older Riverpod element state, not active repeat rendering. |
+| INACTIVE | `lib/features/form_submission/application/element_properties.provider.dart` | Provider references are commented; active widgets use `useStream(element.propertiesChanged)` directly. | High | Not the active rebuild path for repeat rows. |
+| INACTIVE | `lib/features/form_submission/application/submission_creation_model.provider.dart` | Commented provider file. | High | Not active in draft creation; active draft creation is DAO `createDraft`. |
+| INACTIVE | `lib/features/form_submission/application/repository/submission_capture_repository_impl.dart` | Implementation class is commented. | High | Old per-field/value submission logic should not be assumed active. |
+| LEGACY-RISK | `lib/features/form_submission/application/repository/submission_capture_repository.dart` | Interface exists, but no active implementation was found in current form flow. | Medium | Could mislead future work toward a repository abstraction not used by current saves. |
+| INACTIVE | `lib/features/form_submission/application/popup_section.widget.dart` | Entire widget appears commented; factory reference is commented in `form_widget_factory.dart`. | High | Not active repeat UI. |
+| INACTIVE | `lib/features/form_submission/presentation/section/edit_panel.dart` | Alternate edit panel is commented. | High | Not active row edit surface. |
+| LEGACY-RISK | `lib/features/form_submission/presentation/section/edit_row_panel.dart` | Still compiled and imported by repeat UI, but the active `_showEditPanel` path navigates to `EditRowScreen`; `showEditDialog`/panel path appears secondary. | Medium | Could still be called from local dialog code paths; do not delete or modify until runtime confirms. |
+| LEGACY-RISK | `lib/features/form_submission/presentation/section/sliver_form_dialog.dart` | Compiled widget with repeat/field rendering, but no active navigation call was proven in this scan. | Medium | Another possible row/section renderer that could be reintroduced or indirectly used. |
+| LEGACY-RISK | `lib/core/element_instance/form_state.provider.dart` | Comments explicitly mention loading `FormSubmission`, `DataValues`, and `RepeatInstances` from SQLite; active flow uses `FormInstance` built from whole JSON. | Medium | Contains the old normalized repeat/data-value idea. It is conceptually relevant but not active evidence. |
+| LEGACY-RISK | `lib/core/element_instance/data_value_repository.dart` | Directly reads/writes `db.dataValues`; active capture save does not call it, but it is registered in DI and used by display mapping services. | Medium | Data values table exists and can confuse repeat persistence work. It is not active for form save. |
+| LEGACY-RISK | `lib/core/form/data/form_repository_impl.dart` | Implements old form repository using `FormValueStore`; no active form submission screen call path found. | Medium | Old per-value save and validation ideas may not match current whole JSON save. |
+| LEGACY-RISK | `lib/core/form/data/form_value_store.dart` | Referenced by old evaluation utilities and repository code; not found on active `FormInstance.saveFormData` path. | Medium | Looks like a normalized value-store layer that is not current capture persistence. |
+| LEGACY-RISK | `lib/core/form/evaluation_engine/rules/RulesUtilsProviderImpl.dart` and `rules_utils_provider.dart` | Reference `FormValueStore`; active rule evaluation flows through `FormElementInstance`, SDK `RuleAction`, and `ChoiceFilter`. | Medium | Could be confused with the active expression engine; do not alter for repeat rules until proven in use. |
+| UNKNOWN | `lib/features/form_submission/application/evaluation_engine.dart` | No active imports found in current form element evaluation path. | Low | It may be abandoned or experimental; avoid assuming it evaluates repeat expressions. |
+| LEGACY-RISK | `lib/core/form/ui/form_element_renderer.dart` and `form_element_renderer_function.dart` | Renderer abstraction exists, but active form screen uses `FieldFactory`, `SectionWidget`, and `RepeatTableSliver`. | Medium | Not active rendering for repeat rows based on this scan. |
+| INACTIVE | `lib/core/form/builder/element_state_builder.dart` | Repeat build code appears commented. | High | Old repeat builder; active builder is `form_element_builder.dart`. |
+| INACTIVE | `lib/core/form/builder/template_form_control_builder.dart` | Appears to be old/commented builder code. | Medium | Do not tune this for active repeat performance. |
+| LEGACY-RISK | `packages/drun_sdk/lib/database/tables/repeat_instances.table.dart` | Table is included in `AppDatabase`, but active form save stores repeat rows inside `data_submissions.formData`. | Medium | Form-related table name is misleading for current capture. It may be old sync design or future work. |
+| LEGACY-RISK | `packages/drun_sdk/lib/database/dao/repeat_instances_dao.dart` | DAO exists; no active capture save call found. | Medium | Do not use it as proof that repeat rows are separately persisted. |
+| INACTIVE | `packages/drun_sdk/lib/datasource/remote_data_sources/repeat_instance_datasource.dart` | `@Injectable` annotation is commented; `remote_datasource_order_map.dart` comments out `repeatInstance`. | High | Repeat instance sync is not registered in active SDK session datasource list. |
+| LEGACY-RISK | `packages/drun_sdk/lib/database/tables/data_values.table.dart` and `data_values_dao.dart` | Table/DAO exist and are exposed through `DSdk.dataValue`, but current capture save uses `dataInstancesDao.updateData`. | Medium | Data values are not the active repeat/field save path, even if used by display or older code. |
+| INACTIVE | `packages/drun_sdk/lib/datasource/remote_data_sources/data_value_datasource.dart` | `@Injectable` annotation is commented. | High | Data value sync is not part of active form capture sync. |
+| INACTIVE | `packages/drun_sdk/lib/database/tables/metadata_submissions.table.dart` and `remote_data_sources/metadata_submission_datasource.dart` | Table and datasource are commented. | High | Not active local persistence before sync. |
+| INACTIVE | `packages/drun_sdk/lib/datasource/remote_data_sources/form_template_version_datasource.dart` | Injectable/order annotations are commented. Active template datasource extracts form versions. | High | Do not use this as the active form JSON sync path. |
+| LEGACY-RISK | `lib/features/form/presentation/submission_list_page_1.dart`, `_3.dart`, `_4.dart`, `_5.dart` | Static/demo-looking pages reference `dataValues`; no active route registration found in current Stacked routes. | Medium | These pages can confuse the current submission table/form edit path. |
+| INCOMPLETE | `lib/features/form_submission/application/element/field_instance.dart` | `CalculatedFieldInstance.evaluate` contains commented calculation assignment logic at lines 135-143. | High | Calculated fields may declare dependencies but not update values, which matters inside repeat rows. |
+| INCOMPLETE | `lib/features/form_submission/application/element/repeat_item_instance.dart` | `repeatUid` writeback in `reduceValue` is commented at line 47. | High | This is the main incomplete-looking repeat UID persistence point. |
+
+## Repeat UID Behavior Map
+
+Observed active behavior:
+
+1. Existing repeat row JSON may be read from `initialFormValue?['repeatUid']` in `lib/core/form/builder/form_element_builder.dart:69`.
+2. New rows can receive a generated UID in UI save paths in `edit_row_screen.dart` and `repeat_table.widget.dart`.
+3. `RepeatItemInstance.reduceValue()` currently does not write `repeatUid` back into the saved row map because the write line is commented.
+4. `FormInstance.saveFormData()` persists `formSection.value` into one whole `dataInstances.formData` JSON object.
+5. Upload sends that whole `formData` through `DataInstance.toUpload()`.
+
+Classification: INCOMPLETE for persisted repeat UID behavior.
+
+Confidence: high for static evidence; medium for runtime impact because a runtime save test is still needed to prove whether any other layer injects `repeatUid`.
+
+Why this matters: server-submitted records with repeat rows can only preserve stable client row identity if the row UID survives load, edit, save, and upload. Static evidence shows UID read/set points exist, but the central save reduction path appears not to include it.
+
+## Server-Submitted Record Edit Map
+
+Active path:
+
+1. Remote submissions are imported by active `DataInstanceDatasource`/DAO mapping into `DataInstance`.
+2. Base datasource marks remote items `isToUpdate: true`.
+3. Edit routes load the existing `DataInstance` by `submissionId`.
+4. `FormFlowBootstrapperVm` builds the form from existing `instance.formData`.
+5. `FormSubmissionScreen` checks `submissionEditStatusProvider`.
+6. `FormInstance.saveFormData()` writes the edited whole JSON back through `dataInstancesDao.updateData`.
+7. `markSubmissionAsFinal()` makes it eligible for upload.
+8. Upload sends one whole payload and marks successful records synced/updateable.
+
+Classification: ACTIVE.
+
+Confidence: medium-high. Static call paths are clear, but edit permissions and server update semantics need runtime confirmation with a real synced record.
+
+Why this matters: editing a synced repeat-heavy record can rebuild and resave all repeat rows. If repeat UIDs are missing from saved JSON, update matching may be unstable on the server.
+
+## Local Persistence And Cache Before Sync
+
+Active local layers:
+
+- Form definitions: `form_template_versions` table stores JSON-like `fields`, `sections`, and `options`; loaded through `FormTemplateListService` and `FormTemplateRepository`.
+- Submission data: `data_instances`/`data_submissions` table stores one `formData` JSON map per submission.
+- Sync flags: `syncState` and `isToUpdate` live on `DataInstance`.
+- Summary display cache behavior: table summaries extract from nested `formData` through `FormDataUtil` and `FormDataAggregator`; this is derived from saved JSON, not separately captured repeat rows.
+
+Inactive or not active for capture:
+
+- `repeat_instances` table/DAO/datasource.
+- `data_values` capture datasource.
+- `metadata_submissions`.
+- Old `FormValueStore` and `FormRepositoryImpl` capture path.
+
+## Large Repeat Risk Map
+
+| Risk | Evidence | Classification | Confidence | Impact for 200-300 repeat rows |
+| --- | --- | --- | --- | --- |
+| Eager control creation | `FormElementControlBuilder.createRepeatFormArray` maps every initial row into a `FormGroup`. | ACTIVE | High | Opening a large repeat form allocates controls for every row before user interaction. |
+| Eager element tree creation | `FormElementBuilder.buildRepeatInstance` maps every row into `RepeatItemInstance`. | ACTIVE | High | Memory and startup time scale with row count times field count. |
+| Recursive initial dependency evaluation | Bootstrapper calls root `resolveDependencies()` and `evaluate(emitEvent: false)` after full tree build. | ACTIVE | High | Rule setup/evaluation scales across all elements, including repeats. |
+| Repeat-local dependency lookup ambiguity | `findElementInParentSection` walks parent sections then falls back to full tree. | ACTIVE | Medium | Cross-row or same-name fields may resolve unexpectedly; runtime tests needed for nested repeats. |
+| Choice filters per row | `FieldInstance.evaluate` reevaluates choice filters from `evalContext`. | ACTIVE | High | Option-heavy fields inside repeats can multiply expression cost. |
+| Paginated UI with full data source | `RepeatTable` uses `PaginatedDataTable`, but `RepeatTableDataSource` holds all row instances. | ACTIVE | High | Pagination may reduce visible rows but not build/load memory cost. |
+| Whole JSON save on row edit | Repeat row save calls `formInstance.saveFormData()`. | ACTIVE | High | Editing one row serializes and writes the whole form object. |
+| Repeat UID not persisted by reducer | `repeat_item_instance.dart` comments out `repeatUid` writeback. | INCOMPLETE | High | Server updates may not be able to match repeat rows reliably after edit. |
+| Suspicious data source update predicate | `RepeatTableDataSource.updateItems` uses a self-comparison predicate. | UNKNOWN | Medium | Row updates may be broader or less precise than intended; verify behavior before optimizing. |
+| Possible field subscription cleanup issue | `FieldWidget` subscribes to `control.valueChanges`; static scan did not prove cancellation. | UNKNOWN | Medium | Repeated row edit/open cycles may leak listeners if cleanup is wrong. |
+| Duplicate edit-status logic | Bootstrapper and `submissionEditStatusProvider` both compute editability. | LEGACY-RISK | Medium | A synced submission may be editable in one layer and disabled in another if logic diverges. |
+
+## Smallest Set To Understand Before Changing Repeat Performance Or Repeat UID Behavior
+
+Treat these as the minimum "do not touch until understood" set for repeat performance or repeat UID work:
+
+- `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart`
+- `lib/core/form/builder/form_element_control_builder.dart`
+- `lib/core/form/builder/form_element_builder.dart`
+- `lib/features/form_submission/application/element/form_instance.dart`
+- `lib/features/form_submission/application/element/form_element.dart`
+- `lib/features/form_submission/application/element/element_dependency.extension.dart`
+- `lib/features/form_submission/application/element/section_instance.dart`
+- `lib/features/form_submission/application/element/repeat_instance.dart`
+- `lib/features/form_submission/application/element/repeat_item_instance.dart`
+- `lib/features/form_submission/application/element/field_instance.dart`
+- `lib/features/form_submission/presentation/form_submission_screen.widget.dart`
+- `lib/features/form_submission/presentation/form_entry_view_silver.widget.dart`
+- `lib/features/form_submission/presentation/section/section.widget.dart`
+- `lib/features/form_submission/presentation/section/repeat_table_sliver.dart`
+- `lib/features/form_submission/presentation/section/repeat_table.widget.dart`
+- `lib/features/form_submission/presentation/section/repeat_table_rows_source.dart`
+- `lib/features/form_submission/presentation/section/edit_row_screen.dart`
+- `lib/features/form_submission/presentation/field/field.widget.dart`
+- `lib/features/form_submission/application/form_widget_factory.dart`
+- `lib/features/form_submission/application/submission_list.provider.dart`
+- `lib/data/form_template_repository.dart`
+- `lib/data/form_template_list_service.dart`
+- `packages/drun_sdk/lib/database/tables/data_submissions.table.dart`
+- `packages/drun_sdk/lib/database/dao/data_submissions_dao.dart`
+- `packages/drun_sdk/lib/database/extensions/data_submission.extension.dart`
+- `packages/drun_sdk/lib/database/converters/null_aware_map.converter.dart`
+- `packages/drun_sdk/lib/core/form/rule/action.dart`
+- `packages/drun_sdk/lib/core/form/rule/choice_filter.dart`
+- `packages/drun_sdk/lib/core/form/rule/rule_parse_extension.dart`
+- `packages/drun_sdk/lib/core/data_instance/form_data_util.dart`
+- `packages/drun_sdk/lib/core/data_instance/form_data_aggregator.dart`
+
+## Questions Requiring Runtime Confirmation
+
+1. When a new repeat row is saved, does `repeatUid` appear in `data_instances.formData`, or is it lost because `RepeatItemInstance.reduceValue()` does not write it?
+2. When a server-submitted record with repeat rows is edited and re-uploaded, how does the server match repeat rows without a persisted `repeatUid`?
+3. Does `submissionEditStatusProvider` always agree with the bootstrapper's local `submissionEditStatus` logic for synced, draft, finalized, and failed records?
+4. Does `FieldWidget` correctly cancel `control.valueChanges` subscriptions when fields inside repeat edit screens are disposed?
+5. Does `RepeatTableDataSource.updateItems` behave correctly despite the self-comparison predicate?
+6. For nested repeats or repeated field names, does `findElementInParentSection` resolve dependencies to the intended row-local field every time?
+7. How long does bootstrap take on a real form with 200-300 repeat rows and representative choice filters/calculated fields?
+8. Does `PaginatedDataTable` create only visible row widgets, or do row/cell builders still cause expensive traversal across all repeat elements during refresh?
+9. Are `repeat_instances` or `data_values` ever touched by sync/runtime code outside the scanned production form path?
+10. Are calculated fields expected to work in production forms, given that `CalculatedFieldInstance.evaluate` calculation writeback is commented?
+
+## Next Investigation Step
+
+Run one instrumented manual/runtime pass with a real example form containing repeats:
+
+1. Create a draft with two repeat rows, save, and inspect the exact `formData` JSON for `repeatUid`.
+2. Import or use a synced submission with repeat rows, edit one row, save/finalize/upload, and inspect local `formData` plus server response.
+3. Record bootstrap time, number of repeat rows, number of field instances, and whether field subscriptions are disposed after row edit navigation.
+
+Do this before any refactor or optimization so the static map can be corrected with runtime facts.

--- a/docs/agent-context/03-config-fetching.md
+++ b/docs/agent-context/03-config-fetching.md
@@ -1,0 +1,186 @@
+# Config Fetching And Offline Cache Map
+
+Generated: 2026-07-10
+
+Scope: server-to-local fetching for configuration, metadata, assignments, forms, options, org units, teams, and related rows needed for offline work. This complements `01-production-code-path-map.md` and `02-form-flow.md`; it does not remap form rendering or submission save internals except where those depend on synced config.
+
+Status legend:
+
+- ACTIVE: used by reachable production runtime flow.
+- ACTIVE-SEPARATE: reachable production path, but not part of the bulk config sync loop.
+- INACTIVE: present but not referenced by active runtime flow found in this scan.
+- INCOMPLETE: looks like unfinished feature work.
+- LEGACY-RISK: old or duplicate-looking code that could be mistaken for the active path.
+- UNKNOWN: cannot prove either way from static references.
+
+## Executive Map
+
+Active sync path:
+
+1. Login or startup routes the user to `SyncResourcesView`.
+2. `SyncResourcesViewModel.triggerSync()` calls `SyncManager.syncAll()`.
+3. `SyncManager` collects all registered `AbstractDatasource` instances from the active user scope.
+4. Each SDK datasource fetches one server resource through `BaseDataSource.syncWithRemote()`.
+5. The base datasource maps JSON into Drift row objects, upserts rows in a transaction, optionally writes child tables, optionally disables stale rows, and writes a `sync_summaries` row.
+6. Offline screens later read only local Drift tables through DAOs/managers.
+
+Primary active config store:
+
+- A per-user Drift database opened as `datarun_<username>.db`.
+- Form definitions are cached as `form_templates` plus `form_template_versions`.
+- Form elements live inside JSON/text columns on `form_template_versions.fields`, `sections`, and `options`.
+- Assignment access lives in `assignments` plus `assignment_forms`.
+- Org, project, activity, team, option, data element, and permission metadata live in their own local tables.
+
+## Active Trigger And Session Setup
+
+| Area | Classification | File path | Evidence | Confidence | Why it matters |
+| --- | --- | --- | --- | --- | --- |
+| Login-triggered initial sync | ACTIVE | `lib/features/login/presentation/login_viewmodel.dart` | Successful `AuthManager.login(...)` is followed by `replaceWithSyncResourcesView()` at lines 33-35 and 57-59. | High | Fresh login always enters metadata/config sync before home. |
+| Startup-triggered sync | ACTIVE | `lib/features/startup/presentation/splash_viewmodel.dart` | `runStartupLogic()` calls `_syncScheduler.shouldSync()` and routes to `SyncResourcesView` at lines 18-24. | High | Existing users refresh config when online and due. |
+| Manual refresh | ACTIVE | `lib/features/home/presentation/drawer/app_drawer_sync_item.dart` | Drawer item calls `replaceWithSyncResourcesView()` at line 53 when online. | High | Users can explicitly refresh offline config. |
+| Sync due decision | ACTIVE | `lib/core/sync/sync_scheduler.dart` | `shouldSync()` returns false when offline, true when initial sync is missing, or true when interval elapsed at lines 16-22. | High | Offline startup does not force config fetch; existing local DB remains the source. |
+| Sync screen autostart | ACTIVE | `lib/features/sync/presentation/sync_resources_view.dart` | `onViewModelReady` schedules `viewModel.triggerSync()` at lines 77-79. | High | The sync route automatically starts the server fetch. |
+| Sync completion flags | ACTIVE | `lib/features/sync/presentation/sync_resources_viewmodel.dart` | On completed global state, updates `SYNC_DONE` and `LAST_SYNC_TIME` at lines 31-33, then routes home at lines 35-37. | High | These SharedPreferences flags control future startup sync decisions. |
+| User profile fetch | ACTIVE-SEPARATE | `lib/core/auth/auth_api.dart` | Login posts to `/api/v1/authenticate`; profile fetch reads `/api/v1/myDetails` and converts authorities before `UserSession.fromJson`. | High | User/session config is fetched before bulk sync and saved outside the bulk datasource list. |
+| User session activation | ACTIVE | `lib/core/auth/auth_manager.dart` | Login gets user profile at lines 101-105, activates session at line 107, writes session/tokens at lines 109-113, opens user DB and registers `DbManager` at lines 144-159, then calls `registerUserSdkDeps` at line 163. | High | Bulk sync only works after the per-user DB and SDK datasources are registered. |
+| Per-user database file | ACTIVE | `packages/drun_sdk/lib/database/db_factory/platform_app.dart` | Opens `UserFileManager(userId).getUserFile('datarun_$userId.db')` and uses a background Drift connection. | High | Offline metadata is scoped by username. |
+
+## Active Bulk Sync Registration
+
+The active datasource list is generated in `packages/drun_sdk/lib/di/init_active_session_scope.dart:33-60`.
+
+Registered as `AbstractDatasource` and therefore collected by `SyncManager`:
+
+1. `ProjectDatasource`
+2. `ActivityDatasource`
+3. `OuLevelDatasource`
+4. `OrgUnitDatasource`
+5. `OptionSetDatasource`
+6. `DataElementDatasource`
+7. `DataFormTemplateDatasource`
+8. `TeamDatasource`
+9. `UserFormAccessesDatasource`
+10. `AssignmentDatasource`
+11. `DataInstanceDatasource`
+
+Registered but not part of `SyncManager.getAll<AbstractDatasource>()`:
+
+- `ManifestRepository` and `ManifestService` at lines 43-45.
+- `UserDatasource` at line 47.
+
+Why this matters: changing registration order or converting a concrete registration into `AbstractDatasource` changes what the app fetches during config sync. Some tables have foreign keys, so order is not just cosmetic.
+
+## Generic Fetch-Parse-Persist Algorithm
+
+Active implementation: `packages/drun_sdk/lib/datasource/base_datasource.dart`.
+
+| Step | Evidence | Behavior |
+| --- | --- | --- |
+| Fetch | Lines 41-45 and 172-183 | `getOnlineRaw()` GETs `resourcePath`, defaulting to `<resourceName>?paged=false`, and expects `response.data[resourceName]` to be a list. |
+| Extract child rows | Lines 64-82 and 186-193 | Datasources can return `CompanionInsert` rows for auxiliary tables such as options, form versions, managed teams, and assignment forms. |
+| Map JSON | Lines 87-108 and 196-208 | Each JSON item becomes a Drift row. The default mapper injects `id`, `dirty: false`, `isToUpdate: true`, default `label`, and default `translations`, then calls `fromApiJson(..., CustomSerializer())`. |
+| Upsert main rows | Lines 110-116 | Mapped rows are written with `insertAllOnConflictUpdate(table, mapped)`. |
+| Refresh child table | Lines 118-126 | If extras exist, the code deletes all rows from `extra.first.table`, then upserts every extra row. This is a full child-table refresh per datasource, not a per-parent merge. |
+| Disable stale rows | Lines 131-138 | If live IDs exist and fetch did not fail, datasource-specific `disableStale(liveIds)` may run. Base implementation is no-op. |
+| Sync summary | Lines 161-167 | Writes `sync_summaries` with success count, failure count, and serialized errors. |
+
+Important behavior to verify: fetch errors are caught and converted to `syncErrors`, but the method continues with empty data and can still emit a final saved/succeeded progress event unless the database write fails.
+
+## Entity Fetch And Storage Map
+
+| Entity/resource | Classification | Server endpoint/path | Parser/normalizer | Local storage | Stale behavior | Offline consumer evidence | Confidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| User session/profile | ACTIVE-SEPARATE | `POST /api/v1/authenticate`, `GET /api/v1/myDetails` | `AuthApi.getUserProfile` flattens authorities before `UserSession.fromJson`; `AuthStorage` stores active user/session/tokens. | SharedPreferences/session storage/token storage; per-user DB then opens. | Not a bulk datasource refresh. | `AuthManager.login` requires profile before session activation. | High |
+| Projects | ACTIVE | `projects?paged=false` | `ProjectDatasource.fromApiJson` uses default mapping. | `projects` table: `name`, `code`, `disabled`. | No datasource `disableStale` override found. | Activities reference projects. | High |
+| Activities | ACTIVE | `activities?paged=false` | `ActivityDatasource.fromApiJson` collapses nested `project.uid`/`project.id` to `project`. | `activities` table references `projects`; includes disabled/start/end/description. | Overrides `disableStale` to set `disabled = true`. | Assignment list prefetches activity refs. | High |
+| OU levels | ACTIVE | `ouLevels?paged=false` | `OuLevelDatasource.fromApiJson` uses default mapping. | `ou_levels` table: name/code/level/offlineLevels. | No datasource `disableStale` override found. | Org hierarchy support; direct active UI use not deeply traced in this pass. | Medium |
+| Org units | ACTIVE | `orgUnits?paged=false` | `OrgUnitDatasource.fromApiJson` collapses nested `parent.uid`/`parent.id` to `parent`. | `org_units` table: name/code/path/level/parent. | No datasource `disableStale` override found. | Assignment list/detail prefetch org unit refs. | High |
+| Option sets | ACTIVE | `optionSets?paged=false` | `OptionSetDatasource` maps option sets and extracts nested `options` into `DataOption` rows with `optionSet`, `order`, label/translations, and delete flags. | `data_option_sets`; child `data_options`. | No option-set stale override found. Child `data_options` is fully deleted/reinserted when extras exist. | `OptionSetService.getOptions` reads local `dataOptions` and `dataOptionSets` for select fields. | High |
+| Data elements | ACTIVE | `dataElements?paged=false` | `DataElementDatasource.fromApiJson` collapses nested `optionSet.uid` to `optionSet`. | `data_elements` table: value type, optionSet, mandatory/default/scanned-code/resource metadata columns. | No datasource `disableStale` override found. | Form element templates may refer to data element metadata; direct active form rendering mainly uses `form_template_versions` JSON. | Medium |
+| Form templates | ACTIVE | `formTemplates?paged=false` | `DataFormTemplateDatasource.mapRemoteItem` marks disabled; `fromApiJson` treats `disabled` or `deleted` as disabled. | `form_templates`: id/version/name/label/disabled. | Overrides `disableStale` to set `disabled = true`. | Form lists and assignment access query `formTemplates`. | High |
+| Form template versions/elements | ACTIVE | Extra fetch: `formTemplateVersions?paged=false` from `DataFormTemplateDatasource._getFormVersions`. | Each item becomes `FormTemplateVersion` with `id = uid` and `template = templateUid`. Drift converters parse/store `fields`, `sections`, and `options` JSON. | `form_template_versions`: template FK, versionNumber, `fields`, `sections`, `options`. | Child table is fully deleted/reinserted when form template extras exist. Separate `FormTemplateVersionDatasource` is not active. | `FormTemplateListService.getTemplateByVersionOrLatest` and `FormTemplateVersionsDao.selectFormTemplatesWithRefs` read this table to open forms. | High |
+| Teams | ACTIVE | `teams?paged=false` | `TeamDatasource.fromApiJson` collapses nested activity UID and marks disabled if team or activity is disabled. | `teams`; child `managed_teams`. | Overrides `disableStale` to set `disabled = true`. Child `managed_teams` is fully deleted/reinserted when extras exist. | Assignment list/detail prefetch team refs; team fields can read managed teams. | High |
+| Form permissions | ACTIVE | `formPermissions` | `UserFormAccessesDatasource` maps rows directly; `extractId` returns empty string because primary key is team+form. | `user_form_permissions`: team, form, valid dates, permissions list. | No datasource stale override found. | Access is partly represented elsewhere by `assignment_forms`; direct active use of `user_form_permissions` was not proven in this pass. | Medium |
+| Assignments | ACTIVE | `assignments?paged=false` | `AssignmentDatasource.mapRemoteItem` collapses nested activity/orgUnit/team UIDs, defaults status to `PLANNED`, sets `syncState: synced`, and maps disabled. | `assignments`: activity/team/orgUnit FKs, dates, status, syncState, disabled. | Overrides `disableStale` to set `disabled = true`. | Assignment screens read assignments with org/team/activity/form refs. | High |
+| Assignment forms/access | ACTIVE | Extra fetch: `assignments/forms?paged=false` | `_AssignmentWithAccess.fromJson` expands `accessibleForms` into `AssignmentForm` rows. | `assignment_forms`: assignment+form PK, canAdd/canView/canEdit/canDelete flags. | Child table is fully deleted/reinserted when assignment extras exist. | `FormTemplateListService.userAvailableForms` and assignment permission checks read this table. | High |
+| Data submissions | ACTIVE, DATA-NOT-CONFIG | `dataSubmission?paged=false` | `DataInstanceDatasource.fromApiJson` computes form/version id, sets local sync status to synced, maps assignment/orgUnit/team values. | `data_instances`: formTemplate/templateVersion/assignment refs, whole `formData`, sync flags. | No datasource stale override found. | Offline submission list/edit paths read `data_instances`. Covered more fully in `02-form-flow.md`. | High |
+| Sync summaries | ACTIVE | Local only | `BaseDataSource.syncWithRemote` writes one summary row per resource. | `sync_summaries`: entity, lastSync, success/failure count, errors, lastSuccessfulSync. | N/A | Sync summary UI watches `syncSummariesDao.watchAllSummaries`. | High |
+
+## How Key Entities Are Stored Locally
+
+| Local table | Evidence | Stored shape |
+| --- | --- | --- |
+| `form_templates` | `packages/drun_sdk/lib/database/tables/form_templates.table.dart:4-25` | One row per form template with current version UID/number, name, label JSON map, description, disabled. |
+| `form_template_versions` | `packages/drun_sdk/lib/database/tables/form_template_versions.table.dart:8-23` | One row per form version. `fields`, `sections`, and `options` are JSON/text columns mapped by `TemplateListConverter` and `FormOptionListConverter`. |
+| `assignments` | `packages/drun_sdk/lib/database/tables/assignments.table.dart:6-28` | One row per assignment, linked to activity/team/org unit, with instance date, sync state, assignment status, completed date, client update time, disabled. |
+| `assignment_forms` | `packages/drun_sdk/lib/database/tables/assignment_forms.table.dart:4-25` | Join/access table between assignment and form with add/view/edit/delete booleans. |
+| `org_units` | `packages/drun_sdk/lib/database/tables/org_units.table.dart:8-18` | Org unit hierarchy with name/code/path/level/parent. |
+| `activities` | `packages/drun_sdk/lib/database/tables/activities.table.dart:5-18` | Activity rows linked to project and disabled/date/description fields. |
+| `teams` and `managed_teams` | `packages/drun_sdk/lib/database/tables/teams.table.dart:6-12`; `managed_teams.table.dart:5-12` | Team rows linked to activity; managed teams linked to managing team and activity. |
+| `data_option_sets` and `data_options` | `option_sets.table.dart:6-11`; `options.table.dart:6-20` | Option sets and options, including option order, code/name, option-set FK, deletedAt. |
+| `data_elements` | `data_elements.table.dart:7-33` | Metadata for value type, option set, defaults, scanning properties, and resource metadata schema. |
+| `user_form_permissions` | `user_form_permissions.dart:6-20` | Team/form permission rows with converted permissions list. |
+| `data_instances` | `data_submissions.table.dart:9-56` | Offline submission data and synced server submissions as one whole `formData` JSON map plus sync flags. |
+| `sync_summaries` | `sync_summaries.dart:4-20` | Per-resource sync status, counts, serialized errors, and timestamps. |
+
+`AppDatabase` registers both active and inactive-looking tables in one Drift database at `packages/drun_sdk/lib/database/app_database.dart:11-36`; table presence alone does not prove active sync use.
+
+## Offline Consumption After Sync
+
+| Consumer | Evidence | Local rows required |
+| --- | --- | --- |
+| Assignment list | `packages/drun_sdk/lib/database/dao/assignments_dao.dart:97-132` reads non-disabled assignments with prefetched forms, team, activity, and org unit. | `assignments`, `assignment_forms`, `teams`, `activities`, `org_units`. |
+| Assignment detail/access checks | `lib/features/assignment/application/assignment_service_impl.dart:43-83` fetches assignment with org/team/activity/forms; lines 98-142 check assignment form permissions and synced/local submission state. | `assignments`, `assignment_forms`, `form_templates`, `data_instances`. |
+| Available forms | `lib/data/form_template_list_service.dart:23-47` reads `assignmentForms`, then `formTemplates`; lines 111-131 further filter by active user forms and `canAddSubmissions`. | `assignment_forms`, `form_templates`, user session form ids. |
+| Form list/latest version | `lib/data/form_template_list_service.dart:154-180` and `form_template_versions_dao.dart:30-100` join form templates, form versions, and assignment forms to produce `FormTemplateModel`. | `form_templates`, `form_template_versions`, `assignment_forms`. |
+| Form opening | `lib/data/form_template_repository.dart:18-27` loads the selected version and option sets/options before the form tree is built. | `form_template_versions`, `data_option_sets`, `data_options`. |
+| Select/choice fields | `lib/data/option_set_service.dart:11-47` and `72-98` read local options and option sets, filtering out deleted records. | `data_options`, `data_option_sets`. |
+
+## Inactive, Incomplete, Or Duplicate-Looking Paths
+
+| Classification | File path | Evidence | Why it matters |
+| --- | --- | --- | --- |
+| INCOMPLETE | `packages/drun_sdk/lib/service/manifest_service.dart` and `manifest_repository.dart` | Registered in session scope, but no active call to `fetchAndPersistManifest` was found. `persistManifest` mostly contains TODO/commented upsert steps and only records a sync summary. | Looks like a newer context/manifest design for assignments, party sets, and bindings, but it is not the active config sync path. |
+| UNKNOWN/INCOMPLETE | `assignment_manifests`, `party_sets`, `parties`, `party_set_members`, `assignment_party_bindings` tables | Tables are registered in `AppDatabase`, and party resolver code exists, but active server fetch into these tables was not proven. | Do not assume party/manifest tables currently power assignment availability offline. |
+| LEGACY-RISK | `packages/drun_sdk/lib/database/dao/base_dao_extension.dart` and DAO `syncWithRemote` mixins | Many DAOs import `BaseDaoMixin`, which duplicates the datasource fetch/upsert algorithm. Active `SyncManager` calls `AbstractDatasource.syncWithRemote`, not DAO sync methods. | Changing DAO sync code may not affect production config fetch, while changing datasource code will. |
+| LEGACY-RISK | `packages/drun_sdk/lib/datasource/remote_datasource_order_map.dart` | Defines `DSOrder` and ordered datasource type map, including commented/unused resources. Active registration is generated in `init_active_session_scope.dart`. | Useful evidence for intended order, but not the runtime list by itself. |
+| INACTIVE | `DataValueDatasource`, `RepeatInstanceDatasource`, `MetadataSubmissionDatasource`, `FormTemplateVersionDatasource`, `OptionDatasource` | Injectable annotations are commented or these are not registered as active `AbstractDatasource` in `init_active_session_scope.dart`. | Table/datasource names sound form-related but are not active for current config or form capture sync. |
+| LEGACY-RISK | `lib/core/sync_manager/sync_service.provider.dart` | Riverpod `SyncService.performSync` only checks connectivity and writes SharedPreferences; real download call is commented. Active UI uses `SyncResourcesViewModel` and `SyncManager`. | Do not use this provider as the source of truth for config fetching. |
+| ACTIVE-SEPARATE/UNKNOWN | `UserDatasource` | Registered as concrete `UserDatasource`, not as `AbstractDatasource`; active profile fetch is through `AuthApi.getUserProfile`. | It may be usable manually, but it is not part of `SyncManager.syncAll()` based on current registrations. |
+
+## Risks And Questions For Next Pass
+
+1. Does `GetIt.getAll<AbstractDatasource>()` preserve the generated registration order on all targets? The current order matters for FK-linked tables.
+2. Should resources without `disableStale` keep stale rows forever, especially projects, org units, option sets, data elements, form permissions, and data submissions?
+3. Child-table refresh deletes all rows from the child table before reinserting extras. Confirm this is acceptable for `form_template_versions`, `assignment_forms`, `managed_teams`, and `data_options`.
+4. Confirm runtime behavior when one resource fetch fails: the base datasource records errors, but may still emit a final succeeded event and the sync screen may mark global sync done.
+5. Confirm whether `ManifestService` is intended to replace current assignment/forms/party fetching or is abandoned/incomplete.
+6. Confirm whether `user_form_permissions` is still needed, since active form access appears to rely mostly on `assignment_forms`.
+7. Confirm whether syncing `dataSubmission` belongs in the config sync pass or should be separated later from metadata/config refresh.
+
+## Do Not Touch Until Understood
+
+- `lib/features/sync/presentation/sync_resources_viewmodel.dart`
+- `lib/core/sync_manager/sync_manager.dart`
+- `packages/drun_sdk/lib/datasource/base_datasource.dart`
+- `packages/drun_sdk/lib/di/init_active_session_scope.dart`
+- `lib/core/auth/auth_manager.dart`
+- `lib/core/auth/auth_api.dart`
+- `lib/core/auth/auth_storage.dart`
+- `packages/drun_sdk/lib/database/db_factory/database_factory.dart`
+- `packages/drun_sdk/lib/database/db_factory/platform_app.dart`
+- `packages/drun_sdk/lib/database/app_database.dart`
+- `packages/drun_sdk/lib/datasource/remote_data_sources/form_template_datasource.dart`
+- `packages/drun_sdk/lib/datasource/remote_data_sources/assignment_datasource.dart`
+- `packages/drun_sdk/lib/datasource/remote_data_sources/option_set_datasource.dart`
+- `packages/drun_sdk/lib/datasource/remote_data_sources/team_datasource.dart`
+- `packages/drun_sdk/lib/datasource/remote_data_sources/data_submission_datasource.dart`
+- `packages/drun_sdk/lib/datasource/remote_data_sources/org_unit_datasource.dart`
+- `packages/drun_sdk/lib/datasource/remote_data_sources/data_element_datasource.dart`
+- `lib/data/form_template_list_service.dart`
+- `lib/data/form_template_repository.dart`
+- `lib/data/option_set_service.dart`
+- `lib/features/assignment/application/assignment_service_impl.dart`
+- `packages/drun_sdk/lib/database/dao/form_template_versions_dao.dart`
+- `packages/drun_sdk/lib/database/dao/assignments_dao.dart`

--- a/docs/agent-context/04-state-di-runtime-map.md
+++ b/docs/agent-context/04-state-di-runtime-map.md
@@ -1,0 +1,278 @@
+# State, DI, And Runtime Registration Map
+
+Generated: 2026-07-10
+
+Scope: active and inactive-looking state management, dependency injection, generated registrations, runtime scopes, route registration, and service registration. This complements `01-production-code-path-map.md`, `02-form-flow.md`, and `03-config-fetching.md`; it does not remap form rendering or config sync internals except where those depend on runtime state/DI.
+
+Status legend:
+
+- ACTIVE: used by reachable production runtime flow such that commenting/removing it would break app startup/auth/navigation, sync/offline cache, assignment/form access, form load/render/repeat/edit/save, or submission table behavior.
+- SUPPORTING-USED: referenced by reachable production UI, but not required for the core app/forms/sync/data-collection flows to keep working.
+- INACTIVE: not referenced by active runtime flow found in this scan.
+- INCOMPLETE: looks like unfinished feature work.
+- LEGACY-RISK: old or duplicate-looking code that could still be mistaken for active or could be called indirectly.
+- UNKNOWN: cannot prove either way from static references.
+
+Strict active test used in this document: a file is not ACTIVE just because it compiles, is generated, has an injectable/provider annotation, has a form-related name, or is reachable only through stale/commented code. ACTIVE means the currently running production app or a core data-collection flow would fail, lose behavior, or stop building if that path were commented without replacement.
+
+## Executive Map
+
+Active app runtime is a hybrid:
+
+1. `lib/main.dart` is the production entrypoint.
+2. `main()` calls `configureDependencies()` before `runApp(...)`.
+3. `configureDependencies()` registers Stacked services, app-level injectable services, and SDK-level injectable services.
+4. `runApp(...)` wraps the app with a root Riverpod `ProviderScope`.
+5. `MaterialApp` uses generated Stacked routing from `lib/app/stacked/app.router.dart`.
+6. `AuthManager` creates a per-user GetIt scope after login/session restore.
+7. SDK datasource registrations are added to the active user scope by `registerUserSdkDeps(...)`.
+8. Opening a form creates a per-submission GetIt scope containing `FormTemplateRepository` and `FormInstance`.
+9. Form widgets use Riverpod for widget-level async/selection/preference state, but active form state is held in `FormInstance`, `reactive_forms` controls, and scoped GetIt.
+
+Core risk: the app does not have one state system. Riverpod, Stacked viewmodels, ChangeNotifier, GetIt scopes, generated injectable registrations, and `reactive_forms` all participate in the active runtime for startup/auth/sync/forms/submissions.
+
+## Runtime Boot Path
+
+| Step | Classification | File path | Evidence | Confidence | Why it matters |
+| --- | --- | --- | --- | --- | --- |
+| Production entrypoint | ACTIVE | `lib/main.dart` | `main()` initializes Sentry, calls `configureDependencies()`, then `runApp(SentryWidget(child: ProviderScope(child: App(...))))`. | High | Any DI or provider change must preserve this order. |
+| App root state bridge | ACTIVE | `lib/main.dart` | `App extends ConsumerWidget` and watches `authNotifierProvider` plus preference providers for language/theme. | High | Riverpod is active at the root; it is not only feature-local. |
+| Generated Stacked routing | ACTIVE | `lib/main.dart`, `lib/app/stacked/app.router.dart` | `MaterialApp.onGenerateRoute` is `StackedRouter().onGenerateRoute`; initial route is `Routes.splashView`. | High | Route registration determines reachability more strongly than file names. |
+| Stacked app registration | ACTIVE | `lib/app/stacked/app.dart` | `@StackedApp` lists routed pages: `HomeWrapperPage`, `LoginView`, `SplashView`, `SettingsView`, `SyncResourcesView`, `AssignmentScreen`, `EditRowScreen`, `FormSubmissionScreen`, `FormFlowBootstrapper`, and `TableScreen`. | High | Screens not in this route list need separate proof of reachability. |
+| Dependency bootstrap | ACTIVE | `lib/app/di/injection.dart` | `configureDependencies()` calls `setupLocator()`, `setupDialogUi()`, `setupBottomSheetUi()`, `setupGlobalDependencies(appLocator)`, then `setupSdkLocator()`. | High | This is the production DI order. |
+| App locator | ACTIVE | `lib/app/di/injection.dart` | `appLocator = StackedLocator.instance.locator`; old `GetIt.instance` line is commented. | High | Runtime service lookups use Stacked's locator facade. |
+| SDK locator | ACTIVE | `packages/drun_sdk/lib/di/injection.dart` | `rSdkLocator = GetIt.instance`; `setupSdkLocator()` calls `$initSdkGetIt(rSdkLocator)`. | Medium | Static scan proves the SDK registers into `GetIt.instance`; runtime equivalence with `StackedLocator.instance.locator` should be confirmed before altering locator setup. |
+
+## State And Runtime Libraries Found
+
+| Library/pattern | Classification | Evidence | Confidence | Notes |
+| --- | --- | --- | --- | --- |
+| `flutter_riverpod`, `hooks_riverpod`, `riverpod_annotation` | ACTIVE | Declared in `pubspec.yaml`; root `ProviderScope` in `lib/main.dart`; active `@riverpod` providers are used by startup/auth shell, assignment lists, submission tables, form list lookups, and form/submission permissions. | High | Riverpod is active, but each provider still needs separate reachability evidence. |
+| `flutter_hooks` | ACTIVE | Declared in `pubspec.yaml`; active screens/widgets such as `FormSubmissionScreen`, repeat widgets, table screens, assignment screens import hooks. | High | Hook lifecycle interacts with form widgets and scroll/controllers. |
+| `stacked`, `stacked_services`, `stacked_generator` | ACTIVE | Declared in `pubspec.yaml`; `@StackedApp`, generated `app.router.dart`/`app.locator.dart`, Stacked `ViewModelBuilder`, `StackedView`, `BaseViewModel`, and `NavigationService` are active. | High | Navigation and several screen viewmodels depend on this stack. |
+| `get_it`, `injectable`, `injectable_generator` | ACTIVE | Declared in app and SDK pubspecs; `appLocator`, generated `injection.config.dart`, SDK `injection.config.dart`, user scopes, and form scopes are active. | High | Core services, DB, SDK datasources, and form instances are runtime-located through GetIt. |
+| `reactive_forms` | ACTIVE | Declared in `pubspec.yaml`; login form and form submission form use `FormGroup`, `FormArray`, `FormControl`, `ReactiveForm`, and reactive field widgets. | High | Active form value state and repeat rows live in reactive controls. |
+| `ChangeNotifier` | ACTIVE | `AuthManager extends ChangeNotifier`; `LocaleService extends ChangeNotifier`; `ref_extension.provider.dart` wraps them for Riverpod. | High | Changing notifier ownership can break root auth/locale updates. |
+| `StateNotifierProvider` / `StateProvider` old Riverpod style | LEGACY-RISK | Used in `lib/features/team/application/team_state.dart` and `expanded_team_state.dart`; reachable only through `ManageTeamsScreen`, which is not in generated Stacked routes and has only a commented dashboard import. | Medium | Compiles, but route reachability is not proven. Treat as a removal candidate only after runtime/menu confirmation. |
+| `go_router` path | INACTIVE | `lib/app/app_routes/router.dart` and `main.dart` under `app_routes` are fully commented old router code; production `lib/main.dart` uses Stacked router. | High | Do not use `app_routes` as evidence for active navigation. |
+| `rxdart` `BehaviorSubject` sync progress stack | LEGACY-RISK | `SyncProgressNotifier`, `SyncExecutor`, and `SyncCoordinator` are injectable, but routed sync screen uses `SyncManager` directly. References outside generated DI are not proven active. | Medium | There appear to be two sync progress stacks. Changing the inactive-looking one may not affect production sync. |
+
+## Active DI And Scope Map
+
+### Global App Scope
+
+| Registration area | Classification | File path | Evidence | Confidence | Why it matters |
+| --- | --- | --- | --- | --- | --- |
+| Stacked navigation service | ACTIVE | `lib/app/stacked/app.locator.dart` | Generated `setupLocator()` registers `NavigationService`; startup, login, sync, form bootstrap, drawer sync, tables, and assignment detail call `appLocator<NavigationService>()`. | High | Removing it breaks active navigation paths. |
+| Stacked dialog/snackbar/bottom-sheet services | UNKNOWN | `lib/app/stacked/app.locator.dart`, `lib/app/stacked/app.dart` | Generated setup registers `DialogService`, `SnackbarService`, and `BottomSheetService`; exact core use sites were not mapped in this pass. | Medium | Registration exists, but strict ACTIVE requires proving a core path uses each service. |
+| App injectables | ACTIVE | `lib/app/di/injection.config.dart` | `setupGlobalDependencies(...)` registers SharedPreferences, storage, Auth APIs/storage, sync services, repositories, form services, table services, `FieldContextRegistry`, `Dio`, `AuthManager`, and network adapters. | High | This is the main singleton/factory registration source. |
+| Third-party module | ACTIVE | `lib/app/di/third_party_services.module.dart` | Provides `Dio`, `SharedPreferences`, `FlutterSecureStorage`, and Android device info for injectable registrations. | High | API, auth storage, preferences, and form metadata depend on it. |
+| SDK bridge module | ACTIVE | `lib/app/di/sdk_module.dart` | Provides SDK `StorageService` and `TokenStorage` using secure storage or SharedPreferences depending on platform/config. | High | Token/session behavior depends on this bridge. |
+| `FieldContextRegistry` | ACTIVE | `lib/app/di/injection.config.dart`, `lib/features/form_submission/application/field_context_registry.dart` | Registered as lazy singleton; cleared on form screen init; used by `FormInstance` focus/scroll behavior. | High | It is global-looking but used by per-form UI state; repeat and field key changes are risky. |
+| `FormMetadataService` factory param | ACTIVE | `lib/app/di/injection.config.dart`, `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart` | Registered with `factoryParam<FormMetadataService, FormMetadata, dynamic>`; form bootstrap resolves it with `param1: formMetadata`. | High | Form metadata/attributes depend on factory-parameter DI. |
+
+### SDK Base Scope
+
+| Registration area | Classification | File path | Evidence | Confidence | Why it matters |
+| --- | --- | --- | --- | --- | --- |
+| SDK base injectables | ACTIVE | `packages/drun_sdk/lib/di/injection.dart`, `packages/drun_sdk/lib/di/injection.config.dart` | `setupSdkLocator()` registers `DatabaseFactory` and parameterized `UserFileManager`. | High | Per-user DB opening depends on this registration. |
+| Generated active session scope | LEGACY-RISK | `packages/drun_sdk/lib/di/injection.config.dart` | Generated `initActiveSessionContextScope(...)` registers typed `AbstractDatasource<T>` instances under `'activeSessionContext'`, but static search found no call to it. | Medium | Looks intended, but active app calls manual `registerUserSdkDeps(...)` instead. |
+
+### User Scope
+
+| Registration area | Classification | File path | Evidence | Confidence | Why it matters |
+| --- | --- | --- | --- | --- | --- |
+| Per-user scope creation | ACTIVE | `lib/core/auth/auth_manager.dart` | `_activateUserSession(...)` calls `appLocator.pushNewScopeAsync(scopeName: username, init: ...)`. | High | User-scoped DB and SDK datasources live under this scope. |
+| Multiple datasource registration | ACTIVE | `lib/core/auth/auth_manager.dart` | Scope init calls `getIt.enableRegisteringMultipleInstancesOfOneType()`. | High | Required because many SDK datasources register as the same abstract type. |
+| User DB registration | ACTIVE | `lib/core/auth/auth_manager.dart` | Opens `DatabaseFactory.openForUser(username)` and registers `AppDatabase` plus `DbManager`. | High | Offline config/form data resolves through the active user scope. |
+| Active user session | ACTIVE | `lib/core/auth/auth_manager.dart` | Registers `UserSession` with instance name `'activeUser'`. | High | Services/widgets rely on active user context. |
+| User SDK deps | ACTIVE | `lib/core/auth/auth_manager.dart`, `packages/drun_sdk/lib/di/init_active_session_scope.dart` | After pushing the scope, `AuthManager` calls `registerUserSdkDeps(appLocator)`. | High | This is the active datasource registration path for sync. |
+| Locale service | ACTIVE | `lib/core/auth/auth_manager.dart`, `lib/core/auth/ref_extension.provider.dart` | `LocaleService` is registered after user activation and exposed via Riverpod `localeNotifier`. | High | Root locale resolution depends on this user-scoped service after login. |
+| User scope disposal | ACTIVE | `lib/core/auth/auth_manager.dart` | Login/logout use `popScopesTill(username)` when a matching scope exists. | Medium | Scope pop behavior should be runtime-confirmed before changing login/logout or multi-user support. |
+
+### Active SDK Datasource Registrations
+
+`packages/drun_sdk/lib/di/init_active_session_scope.dart` registers these as untyped `AbstractDatasource` factories:
+
+1. `ProjectDatasource`
+2. `ActivityDatasource`
+3. `OuLevelDatasource`
+4. `OrgUnitDatasource`
+5. `OptionSetDatasource`
+6. `DataElementDatasource`
+7. `DataFormTemplateDatasource`
+8. `TeamDatasource`
+9. `UserFormAccessesDatasource`
+10. `AssignmentDatasource`
+11. `DataInstanceDatasource`
+
+Evidence: `SyncManager` builds its resource map from `appLocator.getAll<AbstractDatasource<dynamic>>()`; `SyncResourcesViewModel` calls `SyncManager.syncAll()`.
+
+Why it matters: datasource registration order and type shape affect config fetching and offline tables. The generated `initActiveSessionContextScope(...)` registers typed `AbstractDatasource<T>` instances, while the active manual function registers raw `AbstractDatasource`. Do not change one assuming it changes the other.
+
+### Form Submission Scope
+
+| Registration area | Classification | File path | Evidence | Confidence | Why it matters |
+| --- | --- | --- | --- | --- | --- |
+| Per-submission scope creation | ACTIVE | `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart` | `bootstrapFlow(...)` creates or loads a `DataInstance`, then `pushNewScopeAsync(scopeName: dataInstance.id, init: ...)`. | High | Each open form gets scoped form services. |
+| `FormTemplateRepository` | ACTIVE | `form_flow_bootstrapper_vm.dart` | Registers `FormTemplateRepository.create(versionUid: dataInstance.templateVersion)` in the form scope. | High | Active form rendering uses the loaded flat template from this repository. |
+| `FormInstance` | ACTIVE | `form_flow_bootstrapper_vm.dart` | Registers a built `FormInstance` after creating controls, elements, section tree, metadata attributes, and edit status. | High | This is the active form state object. |
+| Scope drop on same submission | ACTIVE | `form_flow_bootstrapper_vm.dart` | Drops existing scope when `appLocator.currentScopeName == dataInstance.id`. | High | Repeat/edit changes can be affected by stale scoped state. |
+| Scope drop on save/exit | ACTIVE | `lib/features/form_submission/presentation/form_submission_screen.widget.dart` | `NotNow`/`MarkAsFinal` drop current submission scope; back flow calls `popScopesTill(submissionId)` in one branch. | Medium | Exact dispose behavior should be tested with navigation/back stack. |
+
+## Active Riverpod Surface
+
+| Provider area | Classification | File path | Evidence | Confidence | Why it matters |
+| --- | --- | --- | --- | --- | --- |
+| Auth provider bridge | ACTIVE | `lib/core/auth/ref_extension.provider.dart` | `authNotifierProvider` returns `appLocator<AuthManager>()` and notifies Riverpod from `ChangeNotifier`; watched in root `App`. | High | Auth is GetIt-owned but Riverpod-observed. |
+| Locale provider bridge | ACTIVE | `lib/core/auth/ref_extension.provider.dart` | `localeNotifierProvider` wraps `appLocator<LocaleService>()`. | High | Locale is user-scope dependent. |
+| Preferences | ACTIVE | `lib/core/user_session/preference.provider.dart` | Reads/writes `SharedPreferences` through `appLocator`; root app watches language/theme; table appearance and settings use it. | High | Shared preferences are Riverpod state and persistent storage at once. |
+| Login password visibility | ACTIVE | `lib/data/password_visibility.provider.dart` | `LoginView` watches and toggles `passwordVisibilityProvider`; `LoginView` is in Stacked routes. | High | Small active UI state. |
+| App about/version | SUPPORTING-USED | `lib/data/app_about_info.provider.dart` | Settings and drawer version item watch `appAboutInfoProvider`. | High | Referenced by reachable UI, but not required for startup/auth/sync/forms/submissions. |
+| Activity model override | ACTIVE | `lib/features/activity/application/activity.provider.dart` | `ActivityListView` creates nested `ProviderScope` overriding `activityModelProvider`; assignment providers depend on it. | High | Nested ProviderScopes are active and affect assignment filtering. |
+| Assignment list/filter | ACTIVE | `lib/features/assignment/application/assignment_model.provider.dart`, `assignment_filter.provider.dart` | Assignment widgets watch `filterAssignmentsProvider`, `assignmentProvider`, and generated assignment providers; route `AssignmentScreen` is active. | High | Assignment state and form availability depend on these providers. |
+| Teams list for assignment filtering | ACTIVE | `lib/data/teams.provider.dart` | `filterAssignmentsProvider` awaits `teamsProvider().future`. | High | This provider is active through assignment filtering, separate from the old team management screen. |
+| Form list/template providers | ACTIVE | `lib/features/form/application/form_provider.dart` | Form screens and assignment detail/table widgets watch `formListItemsProvider`, `formTemplateProvider`, and `availableUserFormTemplatesProvider`. | High | Form availability and labels are active Riverpod lookups into GetIt services. |
+| Submission edit/status providers | ACTIVE | `lib/features/form_submission/application/submission_list.provider.dart` | `FormSubmissionScreen` and table edit cells watch `submissionEditStatusProvider`. | High | Edit permissions and synced record behavior depend on this provider. |
+| Data instance table providers | ACTIVE | `lib/features/data_instance/application/table.providers.dart`, `table_controller.provider.dart` | `TableScreen`, `PaginatedItemsTable`, and action widgets watch pagination, selection, selected finalized items, appearance, and controller providers. | High | Bulk selection/edit/delete/sync table behavior depends on this state. |
+| Reference-field metadata provider | INCOMPLETE | `lib/data/metadata_submission_update.provider.dart`, `q_reference_drop_down_search_field.widget.dart` | `ValueType.Reference` fields render `QReferenceDropDownSearchField`, which watches `systemMetadataSubmissionsProvider`; provider currently returns `[]` after commented metadata-submission logic. Production use depends on synced form JSON containing `ValueType.Reference`. | High for code state, low for runtime frequency | Do not classify as ACTIVE until a production form proves this field type is exercised. |
+| User org unit provider | LEGACY-RISK | `lib/features/form_submission/application/user_org_units.provider.dart` | Generated provider exists, but found only commented usage in `q_reactive_org_unit_select_field.dart`. | Medium | Do not assume org-unit picker state is active from this provider alone. |
+| Party resolver provider | INCOMPLETE | `lib/core/party/providers/party_resolver.provider.dart` | Generated provider exists; static usage found only generated code. Implementation contains placeholder principals and placeholder party IDs. | High | Party/manifest tables should not be treated as active assignment/form availability until runtime proves this provider is used. |
+| Form integrity provider | UNKNOWN | `lib/data/form_integrity_check_notifier.provider.dart` | Generated provider exists; static usage found only generated code. | Medium | It may be intended for validation UI, but not proven active. |
+| NMC worker sync progress provider | UNKNOWN | `lib/core/sync_manager/nmc_worker/sync_progress.provider.dart` | Generated provider exists; static usage found only generated code. | Medium | Do not confuse with active `SyncResourcesViewModel`/`SyncManager` path. |
+| Riverpod sync service provider | LEGACY-RISK | `lib/core/sync_manager/sync_service.provider.dart` | `SyncService.performSync(...)` has real provider code but the actual download is commented and active sync route uses `SyncManager`. Constants are referenced by old user-session manager code. | Medium | This looks like an older sync facade, not the active config download path. |
+
+## Active Stacked Surface
+
+| Area | Classification | File path | Evidence | Confidence | Why it matters |
+| --- | --- | --- | --- | --- | --- |
+| Route registry | ACTIVE | `lib/app/stacked/app.dart`, `app.router.dart` | Generated router contains route entries and navigation extension methods for every `@StackedApp` route. | High | Use this route list to judge active screens first. |
+| Startup | ACTIVE | `lib/features/startup/presentation/splash_view.dart`, `splash_viewmodel.dart` | `SplashView` is routed; viewmodel routes to login, sync, or home. | High | Startup decides whether sync/config fetching runs. |
+| Login | ACTIVE | `lib/features/login/presentation/login_view.dart`, `login_viewmodel.dart` | `LoginView` is routed and uses `ViewModelBuilder<LoginViewModel>.reactive`. | High | Old `LoginScreen` is not the routed login page. |
+| Sync resources | ACTIVE | `lib/features/sync/presentation/sync_resources_view.dart`, `sync_resources_viewmodel.dart` | `SyncResourcesView` is routed; viewmodel owns `SyncManager` stream and completion navigation. | High | Active config fetch UI path. |
+| Form bootstrap | ACTIVE | `lib/features/form_submission/presentation/form_flow_bootstrapper.dart`, `form_flow_bootstrapper_vm.dart` | Routed by `FormFlowBootstrapper`; extends `StackedView<FormFlowBootstrapperVm>`. | High | Owns creation of per-submission GetIt scope. |
+| Home/activity shell and drawer sync entry | ACTIVE | `home_wrapper_page.dart`, `app_drawer.dart`, `app_drawer_sync_item.dart`, `activity_list_view.dart` | Routed/home paths use Stacked and Riverpod widgets; drawer sync item routes to `SyncResourcesView`. | Medium/High | This is part of reaching synced/offline data-collection flows. |
+| Settings/about UI | SUPPORTING-USED | `settings_view.dart`, `user_settings_tab_view.dart`, `app_drawer_version_item.dart` | Settings route exists and widgets watch supporting providers. | Medium | Referenced by reachable UI, but not core form/sync/submission behavior under the strict active test. |
+| Dialogs/bottom sheets | UNKNOWN | `lib/app/stacked/app.dart`, generated dialogs/bottomsheets | `InfoAlertDialog` and `NoticeSheet` are registered through Stacked generator, but exact core use sites were not mapped in this pass. | Medium | Registration alone is not enough to classify as ACTIVE under the strict test. |
+
+## Inactive, Incomplete, Or Legacy-Risk State/DI Code
+
+| Classification | File path | Evidence | Confidence | Why it matters |
+| --- | --- | --- | --- | --- |
+| INACTIVE | `lib/app/app_routes/main.dart` | File is commented out; production `lib/main.dart` is active and uses Stacked router. | High | Do not use this as entrypoint evidence. |
+| INACTIVE | `lib/app/app_routes/router.dart` | File is commented out; imports `go_router`; generated Stacked router is active instead. | High | Old route names/screens here do not prove reachability. |
+| INACTIVE | `lib/app/app_routes/auth.dart` | Defines mock `DatarunAuth`; static references found only within the file. | High | Not part of production auth; active auth is `AuthManager`. |
+| INACTIVE | `lib/features/login/presentation/login_screen.dart`, `login_screen_viewmodel.dart` | Obsolete-looking path: static refs show only self-imports and commented old router references; Stacked route uses `LoginView`. | High | Avoid fixing wrong login page. |
+| INACTIVE | `lib/core/element_instance/form_state.provider.dart` | Obsolete-looking path: entire provider implementation is commented and references old `D2Remote`/old template names. | High | Not active form state. |
+| INACTIVE | `lib/features/form_submission/application/form_instance.provider.dart` | Obsolete-looking path: entire Riverpod `FormInstance` provider path is commented; active form screen comments show it was replaced by `appLocator<FormInstance>()`. | High | Active form state is scoped GetIt, not this provider. |
+| INACTIVE | `lib/features/form_submission/application/element/form_element_instance.provider.dart` | Obsolete-looking path: entire file is commented and contains unimplemented provider sketches. | High | Not active element state. |
+| INACTIVE | `lib/features/form/application/form/form_state/state_riverpod.dart` | Obsolete-looking path: commented `StateProvider.family` attempt. | High | Not active field state. |
+| INACTIVE | `lib/features/form/application/form/form_state/table_state_notifier.provider.dart` | Obsolete-looking path: commented `@riverpod` table state sketch. | High | Not active repeat/table state. |
+| INACTIVE | `lib/data/completion_dialog_config.provider.dart` | Obsolete-looking path: fully commented provider; active completion dialog is configured directly in `FormSubmissionScreen` using `ConfigureFormCompletionDialog`. | High | Do not change this expecting save/check dialog changes. |
+| INACTIVE | `lib/data/controller.provider.dart` | Obsolete-looking path: fully commented settings provider referencing old org-unit picker/settings code. | High | Not active settings state. |
+| INACTIVE | `lib/data/org_unit/ou_picker_data_source.provider.dart` | Obsolete-looking path: fully commented provider referencing older data model paths. | High | Not active org-unit selection state. |
+| INACTIVE | `lib/features/form_submission/application/submission_creation_model.provider.dart` | Obsolete-looking path: fully commented provider referencing old `data_run/...` paths. | High | Not active submission creation path. |
+| INACTIVE | `lib/features/form_submission/presentation/field/date_time_main.dart` | Demo path: contains its own `runApp(const MyApp())`; static search found no import/use from production entrypoint. | High | Demo/test entrypoint, not production date field path. |
+| LEGACY-RISK | `lib/features/team/presentation/managed_team_screen.dart`, `lib/features/team/application/team_state.dart`, `expanded_team_state.dart` | `ManageTeamsScreen` uses local fake `teamSummaries`; not in Stacked routes; only external reference found is commented dashboard import. | Medium | Team state exists but active team data for assignments uses `lib/data/teams.provider.dart`. |
+| LEGACY-RISK | `lib/core/sync/sync_coordinator.dart`, `sync_executor.dart`, `sync_progress_notifier.dart` | Injectable registrations exist, but active `SyncResourcesViewModel` uses `SyncManager`; no routed call to `SyncCoordinator` found. | Medium | Duplicate sync state path can confuse refactors. |
+| INCOMPLETE | `lib/core/party/providers/party_resolver.provider.dart` | Placeholder user/team/party IDs; generated provider exists but no static use outside generated file. | High | Party resolution appears not production-ready. |
+| INCOMPLETE | `lib/data/metadata_submission_update.provider.dart` | Provider is used by Reference field widgets but currently returns empty list after commented metadata-submission lookup; production form JSON use of `ValueType.Reference` was not confirmed. | High | Reference fields are reachable by value type, but data backing is incomplete and not proven core-active. |
+| LEGACY-RISK | `packages/drun_sdk/lib/di/injection.config.dart` generated `initActiveSessionContextScope(...)` | Generated typed datasource registration exists but no call was found; active user scope calls manual `registerUserSdkDeps(...)`. | Medium | Future DI regeneration could revive or alter this path. |
+
+## Candidate Duplicate Runtime Paths
+
+These are observations only; no removal is recommended yet.
+
+| Area | Candidate duplicate paths | Current evidence |
+| --- | --- | --- |
+| Routing | `lib/app/stacked/*` vs `lib/app/app_routes/*` | Stacked is active; `app_routes` is commented/obsolete-looking. |
+| Login UI | `LoginView` vs `LoginScreen` | `LoginView` is routed; `LoginScreen` is only self-referenced and commented old-router referenced. |
+| Form instance state | Scoped GetIt `FormInstance` vs commented Riverpod `form_instance.provider.dart` | Active screen uses `appLocator<FormInstance>()`; old provider is commented. |
+| Form/field Riverpod state | Active `reactive_forms`/`FormInstance` vs commented `form_state.provider.dart` and `state_riverpod.dart` | Active form bootstrap builds `FormGroup` and `Section`; old providers are commented. |
+| Sync orchestration | `SyncManager`/`SyncResourcesViewModel` vs `SyncCoordinator`/`SyncExecutor`/`SyncProgressNotifier` vs `SyncService` provider | Routed sync uses `SyncManager`; other stacks are injectable/provider code but not proven routed. |
+| SDK datasource registration | Manual `registerUserSdkDeps(...)` vs generated `initActiveSessionContextScope(...)` | Active auth manager calls manual function; generated function not called by static refs. |
+| Team state | `lib/data/teams.provider.dart` vs `features/team/application/team_state.dart` | Assignment filtering uses `lib/data/teams.provider.dart`; management screen state not routed. |
+
+## Risk Map For Refactoring
+
+| Risk area | Classification | Why it is risky | Files to understand first |
+| --- | --- | --- | --- |
+| Locator identity | UNKNOWN | App `appLocator` comes from `StackedLocator.instance.locator`; SDK uses `GetIt.instance`. They appear to cooperate in the current app, but static scan should be confirmed at runtime. | `lib/app/di/injection.dart`, `packages/drun_sdk/lib/di/injection.dart` |
+| Scope nesting | ACTIVE | High risk: user scope and form submission scope are both GetIt scopes. A service lookup may resolve from current form scope, user scope, or root scope depending on current stack. | `lib/core/auth/auth_manager.dart`, `form_flow_bootstrapper_vm.dart`, `form_submission_screen.widget.dart` |
+| Multiple registrations of same type | ACTIVE | High risk: datasources require `enableRegisteringMultipleInstancesOfOneType()` and raw `AbstractDatasource` registrations. Typed vs untyped changes can alter `getAll(...)` results. | `auth_manager.dart`, `init_active_session_scope.dart`, `sync_manager.dart`, `sync_executor.dart` |
+| Form state ownership | ACTIVE | High risk: form widgets are Riverpod/Hook widgets, but active form data lives in `FormInstance` and `reactive_forms` controls from GetIt scope. | `form_flow_bootstrapper_vm.dart`, `form_instance.dart`, `field.widget.dart`, repeat widgets |
+| Field key registry | ACTIVE | High risk: `FieldContextRegistry` is app-level lazy singleton but cleared during form screen init and used by form instance focus/scroll. | `field_context_registry.dart`, `form_submission_screen.widget.dart`, `form_instance.dart` |
+| Sync stack duplication | LEGACY-RISK | There are multiple sync abstractions; active config fetching uses one, but generated DI registers another. | `sync_resources_viewmodel.dart`, `sync_manager.dart`, `sync_coordinator.dart`, `sync_executor.dart`, `sync_service.provider.dart` |
+| Generated files | ACTIVE | High risk: Stacked, injectable, Riverpod, and Drift generated files influence runtime. Manual edits may be overwritten; stale generated code can mislead scans. | `app.router.dart`, `app.locator.dart`, `injection.config.dart`, active `*.provider.g.dart`, Drift generated DB files |
+| Conditional provider paths | INCOMPLETE | Reference field metadata path is only exercised by forms containing `ValueType.Reference`; static route reachability alone cannot prove production usage frequency. | `form_widget_factory.dart`, `q_reference_drop_down_search_field.widget.dart`, `metadata_submission_update.provider.dart` |
+
+## Do Not Touch Until Understood
+
+Runtime bootstrap and registration:
+
+- `lib/main.dart`
+- `lib/app/di/injection.dart`
+- `lib/app/di/injection.config.dart`
+- `lib/app/di/third_party_services.module.dart`
+- `lib/app/di/sdk_module.dart`
+- `lib/app/stacked/app.dart`
+- `lib/app/stacked/app.router.dart`
+- `lib/app/stacked/app.locator.dart`
+- `packages/drun_sdk/lib/di/injection.dart`
+- `packages/drun_sdk/lib/di/injection.config.dart`
+- `packages/drun_sdk/lib/di/init_active_session_scope.dart`
+
+Session and DB scope:
+
+- `lib/core/auth/auth_manager.dart`
+- `lib/core/auth/ref_extension.provider.dart`
+- `lib/core/user_session/preference.provider.dart`
+- `packages/drun_sdk/lib/database/db_factory/database_factory.dart`
+- `packages/drun_sdk/lib/database/db_factory/platform_app.dart`
+
+Form/repeat state:
+
+- `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart`
+- `lib/features/form_submission/presentation/form_submission_screen.widget.dart`
+- `lib/features/form_submission/application/element/form_instance.dart`
+- `lib/features/form_submission/application/field_context_registry.dart`
+- `lib/features/form_submission/application/form_widget_factory.dart`
+- `lib/features/form_submission/presentation/section/repeat_table.widget.dart`
+- `lib/features/form_submission/presentation/section/repeat_table_sliver.dart`
+- `lib/features/form_submission/presentation/section/edit_row_screen.dart`
+- `lib/features/form_submission/presentation/section/edit_row_panel.dart`
+
+Active Riverpod app state:
+
+- `lib/features/assignment/application/assignment_model.provider.dart`
+- `lib/features/assignment/application/assignment_filter.provider.dart`
+- `lib/data/teams.provider.dart`
+- `lib/features/form/application/form_provider.dart`
+- `lib/features/form_submission/application/submission_list.provider.dart`
+- `lib/features/data_instance/application/table.providers.dart`
+- `lib/features/data_instance/application/table_controller.provider.dart`
+
+Sync/runtime duplication:
+
+- `lib/core/sync_manager/sync_manager.dart`
+- `lib/features/sync/presentation/sync_resources_viewmodel.dart`
+- `lib/core/sync/sync_coordinator.dart`
+- `lib/core/sync/sync_executor.dart`
+- `lib/core/sync/sync_progress_notifier.dart`
+- `lib/core/sync_manager/sync_service.provider.dart`
+
+## Questions Requiring Runtime Confirmation
+
+1. Does `StackedLocator.instance.locator` resolve to the same underlying GetIt instance as SDK `GetIt.instance` on all supported platforms?
+2. What is the exact scope stack after login, after opening a form, after saving, after back navigation, and after logout?
+3. Does `GetIt.getAll<AbstractDatasource<dynamic>>()` return the manual raw datasource registrations in the expected order after every login/session restore?
+4. Is generated `initActiveSessionContextScope(...)` ever called indirectly by generated code or build tooling, or is it fully dead?
+5. Are `SyncCoordinator`/`SyncExecutor` used by any background task, settings action, or future route not visible in static route scans?
+6. Is `ManageTeamsScreen` reachable through any manual `Navigator.push` or feature flag outside the generated Stacked route list?
+7. Do production forms contain `ValueType.Reference` fields, and if yes is the current empty metadata submission provider accepted behavior or a broken incomplete feature?
+8. Does form scope disposal always run when the user leaves a form through Android back, app backgrounding, route replacement, or completion dialog actions?
+9. After the tooling branch is merged, do generated Riverpod/injectable/Stacked outputs still match this map?
+
+## Next Investigation Step
+
+The next useful pass should be a runtime verification pass, not a refactor: add temporary instrumentation or use debugger/logs to capture the GetIt scope stack and registered types during startup, login, sync, form open, repeat add/edit, save, and logout. That pass should update this document and the form-flow/config maps before any state-management cleanup starts.

--- a/docs/agent-context/05-classification-reconciliation.md
+++ b/docs/agent-context/05-classification-reconciliation.md
@@ -1,0 +1,201 @@
+# Classification Reconciliation Pass
+
+Generated: 2026-07-10
+
+Scope: reconcile `01-production-code-path-map.md`, `02-form-flow.md`, `03-config-fetching.md`, and `04-state-di-runtime-map.md` under a stricter active-code definition. This document is an overlay on the earlier maps: it does not invalidate their evidence, but it supersedes older classifications where later scans proved a narrower label.
+
+## Strict Legend
+
+- ACTIVE: commenting/removing the path without replacement would break app startup/auth/navigation, sync/offline cache, assignment/form access, form load/render/repeat/edit/save, or submission table behavior.
+- SUPPORTING-USED: referenced by reachable production UI or helper flows, but core app/forms/sync/data-collection would still run if the feature were removed intentionally.
+- INACTIVE: not referenced by the active runtime flow found in static scans.
+- INCOMPLETE: reachable or plausible code exists, but the implementation is unfinished, placeholder-based, or returns empty/no-op data.
+- LEGACY-RISK: old, duplicate, registered-only, or conceptually related code that could be mistaken for active, but is not proven to be required by the current core flow.
+- UNKNOWN: static evidence cannot prove whether the path is required.
+
+Strict comment-out test: ACTIVE is not assigned just because a file compiles, is generated, appears in DI, is imported by another non-core file, has a form-looking/table-looking name, or is reachable only through stale/commented code. A path is ACTIVE only when removing it would break the running app or a current core data-collection feature.
+
+## Main Finding
+
+Yes, the earlier passes contain some over-classifications. The largest source is `01-production-code-path-map.md`, whose legend used "reachable through entrypoints, DI, imports, routes, or direct call sites" as active evidence. That was useful for first mapping, but too broad for demotion/removal planning.
+
+The second source is `03-config-fetching.md`, where "ACTIVE" sometimes means "registered in the bulk sync datasource list" and sometimes means "required by offline consumers." Those are different. Under the strict test, a datasource can be active as part of the sync loop while the table it fills may still be supporting, conditional, or unproven for a specific form feature.
+
+`02-form-flow.md` is mostly aligned for the form/repeat/save path, but a few rows should be read more narrowly: active widget use is not the same as active generated route registration, and display/summary helpers are not the same as form load/save core.
+
+`04-state-di-runtime-map.md` already introduced the stricter test. This pass adds one correction to it: `DialogService` is ACTIVE, while `SnackbarService` and Stacked `BottomSheetService` remain unproven.
+
+## Reconciled Corrections
+
+| Earlier map area | Earlier label | Reconciled label | Evidence and correction |
+| --- | --- | --- | --- |
+| `01` status legend | Active if reachable/imported/registered/routed | Use this document's strict labels | The old label is too broad for cleanup. Treat `01` "Active" as "reachable evidence" unless confirmed by `02`, `03`, `04`, or this document. |
+| Generated Stacked router and locator | Active generated code | ACTIVE | `lib/main.dart` uses `StackedRouter().onGenerateRoute`; active navigation uses `NavigationService`. Generated route/locator output is required, but should not be edited manually. |
+| Stacked `SettingsView` and about/version UI | Active route/UI | SUPPORTING-USED | Settings is routed, but removing settings/about display would not break startup, sync, form capture, repeat edit, save, or submission table behavior. |
+| Stacked `DialogService` | UNKNOWN in `04` | ACTIVE | `DExceptionReporter` uses `appLocator<DialogService>().showDialog(...)`; login/startup/form-template error paths call the reporter. `details_submissions_table.dart` also calls `showCustomDialog(...)`. |
+| Stacked `SnackbarService` | Registered/generated | UNKNOWN | Static scan found registration but no required core call site. Do not classify active from generated registration alone. |
+| Stacked `BottomSheetService` | Registered/generated | UNKNOWN | Active form completion uses Flutter `showModalBottomSheet`, not Stacked `BottomSheetService`. Generated registration alone is not enough. |
+| `EditRowScreen` widget | ACTIVE in `02` | ACTIVE | Repeat edit constructs `EditRowScreen` through `NavigationService.navigateToView(...)`; commenting the widget would break active repeat editing. |
+| `EditRowScreen` generated Stacked route | ACTIVE in `02` | LEGACY-RISK | The generated `navigateToEditRowScreen` route was not proven required because the active repeat edit path constructs the widget through `navigateToView(...)`. |
+| `EditRowPanel` and dialog repeat edit path | LEGACY-RISK in `02` | LEGACY-RISK | `showEditDialog(...)` exists and builds `EditRowPanel`, but active `_showEditPanel(...)` always takes the `if (true)` branch and navigates to `EditRowScreen`. |
+| Riverpod as a library | ACTIVE | ACTIVE | Root `ProviderScope` and many providers are active, but every provider still needs per-provider evidence. Generated `*.provider.g.dart` files are not active unless their provider is watched by a core path. |
+| Old team `StateNotifierProvider` files | Active-looking Riverpod state | LEGACY-RISK | `ManageTeamsScreen` is not in Stacked routes and only had a commented dashboard reference. Active assignment filtering uses `lib/data/teams.provider.dart`, not `features/team/application/team_state.dart`. |
+| `SyncCoordinator`, `SyncExecutor`, `SyncProgressNotifier` | Registered injectables | LEGACY-RISK | They are in generated DI, but active sync route uses `SyncResourcesViewModel` plus `SyncManager`. No routed call to `SyncCoordinator` was found. |
+| `syncServiceProvider` | Provider exists | LEGACY-RISK | `performSync` does not perform the real download; active config sync uses `SyncManager.syncAll()`. Constants may still be referenced by old services. |
+| SDK `initActiveSessionContextScope(...)` | Generated active session scope | LEGACY-RISK | Generated typed datasource registration exists, but active auth calls manual `registerUserSdkDeps(appLocator)`. Do not refactor the generated scope assuming production uses it. |
+| `UserDatasource` | Mixed/uncertain in `03` | LEGACY-RISK | It is registered as concrete `UserDatasource`, not collected by `SyncManager.getAll<AbstractDatasource>()`; active profile fetch is `AuthApi.getUserProfile`. |
+| `ManifestService` / manifest tables | INCOMPLETE in `03` | INCOMPLETE | Registered services and tables exist, but no active `fetchAndPersistManifest` path was found; implementation has TODO/commented persistence. |
+| Bulk `AbstractDatasource` list | ACTIVE | ACTIVE | The 11 raw `AbstractDatasource` registrations in `init_active_session_scope.dart` are core to current config sync because `SyncManager` collects them. |
+| `DataElementDatasource` | ACTIVE in `01`/`03` | ACTIVE | The datasource is in the `AbstractDatasource` sync loop. |
+| `data_elements` table as form-render source | ACTIVE in `01`/`03` | SUPPORTING-USED | Direct form rendering mainly uses `form_template_versions` JSON; `data_elements` supports display/value metadata and older data-value paths. |
+| `UserFormAccessesDatasource` | ACTIVE in `03` | ACTIVE | The datasource is in the `AbstractDatasource` sync loop. |
+| `user_form_permissions` as access gate | ACTIVE in `03` | UNKNOWN | Active form access checks found in later passes rely mostly on `assignment_forms`; direct production use of `user_form_permissions` was not proven. |
+| `assignment_forms` | ACTIVE | ACTIVE | Used by available forms, assignment detail access, edit permissions, and form list filtering. This is the active form-access table. |
+| `sync_summaries` | ACTIVE in `03` | SUPPORTING-USED | `BaseDataSource` writes summaries, but `SyncSummaryCard` is only found in commented settings UI. Core sync completion uses progress/global state and SharedPreferences flags. |
+| `DataValueRepository` display helper | Partially active in `01`, LEGACY-RISK in `02` | SUPPORTING-USED | `DataValueRepository` is used by `MapValueToDisplay`, but this is display support, not current capture persistence. |
+| `data_values` table/DAO as capture storage | Partially active in `01`, LEGACY-RISK in `02` | LEGACY-RISK | Active form save writes `data_instances.formData`, not per-field `data_values`. |
+| `repeat_instances` table/DAO | LEGACY-RISK in `02`, inactive-looking in `01` | LEGACY-RISK | Table/DAO exist, but active repeat rows are stored in `data_instances.formData` as nested JSON lists. |
+| `metadata_submissions` and `systemMetadataSubmissionsProvider` | Inactive/incomplete in `01`/`03`, incomplete in `04` | INCOMPLETE | Reference widgets can watch the provider, but it currently returns `[]` after commented DB logic. Production use depends on forms containing `ValueType.Reference`. |
+| `partyResolverProvider` and party/manifest tables | Mixed/uncertain in `03`, INCOMPLETE in `04` | INCOMPLETE | Provider contains placeholder user/team/party IDs and no static production consumer was found. |
+| Form route/load/save/repeat core in `02` | ACTIVE | ACTIVE | `FormFlowBootstrapperVm`, `FormTemplateRepository`, `FormElementControlBuilder`, `FormElementBuilder`, `FormInstance`, repeat models/widgets, and `DataInstancesDao.updateData` pass the strict test. |
+| Form summary utilities | ACTIVE in `02` | ACTIVE | `FormDataUtil`/`FormDataAggregator` are active through submission table summaries, but not part of form load/save/repeat persistence. |
+| `CodeGenerator` | ACTIVE in `02` | ACTIVE | Active for submission IDs and referenced by repeat UID UI code. It does not prove repeat UID persistence, which remains INCOMPLETE because `RepeatItemInstance.reduceValue()` does not write `repeatUid`. |
+| Example/debug `main()` functions inside helper files | Mentioned as examples | INACTIVE | Files like date-time demos or aggregator examples are not production entrypoints unless imported by `lib/main.dart` or routed production paths. |
+
+## Strict Active Core To Carry Forward
+
+These are the paths that should remain treated as core-active until runtime proves otherwise.
+
+App/session/bootstrap:
+
+- `lib/main.dart`
+- `lib/app/di/injection.dart`
+- `lib/app/di/injection.config.dart`
+- `lib/app/di/third_party_services.module.dart`
+- `lib/app/di/sdk_module.dart`
+- `lib/app/stacked/app.dart`
+- `lib/app/stacked/app.router.dart`
+- `lib/app/stacked/app.locator.dart`
+- `lib/core/auth/auth_manager.dart`
+- `lib/core/auth/ref_extension.provider.dart`
+- `lib/core/user_session/preference.provider.dart`
+
+Sync/offline cache:
+
+- `lib/features/sync/presentation/sync_resources_view.dart`
+- `lib/features/sync/presentation/sync_resources_viewmodel.dart`
+- `lib/core/sync_manager/sync_manager.dart`
+- `packages/drun_sdk/lib/datasource/base_datasource.dart`
+- `packages/drun_sdk/lib/di/init_active_session_scope.dart`
+- Active `AbstractDatasource` implementations registered by `registerUserSdkDeps(...)`
+- `packages/drun_sdk/lib/database/db_factory/database_factory.dart`
+- `packages/drun_sdk/lib/database/db_factory/platform_app.dart`
+- `packages/drun_sdk/lib/database/app_database.dart`
+
+Assignment/form access and listing:
+
+- `lib/features/assignment/application/assignment_model.provider.dart`
+- `lib/features/assignment/application/assignment_filter.provider.dart`
+- `lib/features/assignment/application/assignment_service_impl.dart`
+- `lib/data/teams.provider.dart`
+- `lib/data/form_template_list_service.dart`
+- `lib/features/form/application/form_provider.dart`
+- `packages/drun_sdk/lib/database/dao/assignments_dao.dart`
+- `assignment_forms` table and access queries
+
+Form/repeat/save:
+
+- `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart`
+- `lib/data/form_template_repository.dart`
+- `lib/core/form/builder/form_element_control_builder.dart`
+- `lib/core/form/builder/form_element_builder.dart`
+- `lib/features/form_submission/application/element/form_instance.dart`
+- `lib/features/form_submission/application/element/form_element.dart`
+- `lib/features/form_submission/application/element/section_instance.dart`
+- `lib/features/form_submission/application/element/repeat_instance.dart`
+- `lib/features/form_submission/application/element/repeat_item_instance.dart`
+- `lib/features/form_submission/application/element/field_instance.dart`
+- `lib/features/form_submission/presentation/form_submission_screen.widget.dart`
+- `lib/features/form_submission/presentation/section/repeat_table.widget.dart`
+- `lib/features/form_submission/presentation/section/repeat_table_rows_source.dart`
+- `lib/features/form_submission/presentation/section/edit_row_screen.dart`
+- `packages/drun_sdk/lib/database/dao/data_submissions_dao.dart`
+- `packages/drun_sdk/lib/database/tables/data_submissions.table.dart`
+- `packages/drun_sdk/lib/database/extensions/data_submission.extension.dart`
+
+Submission table:
+
+- `lib/features/data_instance/application/table.providers.dart`
+- `lib/features/data_instance/application/table_controller.provider.dart`
+- `lib/features/data_instance/data/drift_table_repository.dart`
+- `lib/features/data_instance/presentation/table_screen.dart`
+- `lib/features/data_instance/presentation/table_widget.dart`
+- `packages/drun_sdk/lib/core/data_instance/form_data_util.dart`
+
+## Supporting Or Conditional Paths
+
+These are used or plausible, but should not be treated as core-active without more proof.
+
+| Path | Reconciled label | Reason |
+| --- | --- | --- |
+| `lib/data/app_about_info.provider.dart` | SUPPORTING-USED | Version/about display only. |
+| Settings screens and appearance/preferences UI | SUPPORTING-USED | Reachable UI, but not core data-collection behavior. Preference provider itself remains ACTIVE because root app and table appearance use it. |
+| `SyncSummaryCard` and `sync_summaries` UI | SUPPORTING-USED | Summary writes happen during sync, but the UI consumer found in settings is commented. |
+| `DataValueRepository` / `data_values` | SUPPORTING-USED | Display helper use exists; capture/save does not use this path. Treat `data_values` as LEGACY-RISK for storage design. |
+| `data_elements` table | SUPPORTING-USED | Synced actively, used by display/older metadata helpers, but not the primary form JSON source. |
+| `ValueType.Reference` widgets and metadata provider | INCOMPLETE | Field factory can route to reference widgets, but provider returns empty data and production form use is unconfirmed. |
+| `UserFormAccessesDatasource` table output | UNKNOWN | Synced actively, but active access checks rely on `assignment_forms`. |
+| `DialogService` custom info dialog | ACTIVE | Error reporting and a test upload dialog use it. |
+| Stacked `SnackbarService` / `BottomSheetService` | UNKNOWN | Registered, but no core active call site found. |
+
+## Demotion Candidates
+
+Do not delete these yet, but they are strong candidates for demotion/removal after runtime confirmation.
+
+- `lib/app/app_routes/*`
+- `lib/features/login/presentation/login_screen.dart`
+- `lib/features/login/presentation/login_screen_viewmodel.dart`
+- `lib/features/team/presentation/managed_team_screen.dart`
+- `lib/features/team/application/team_state.dart`
+- `lib/features/team/application/expanded_team_state.dart`
+- `lib/features/form_submission/application/form_instance.provider.dart`
+- `lib/features/form_submission/application/element/form_element_instance.provider.dart`
+- `lib/core/element_instance/form_state.provider.dart`
+- `lib/features/form/application/form/form_state/state_riverpod.dart`
+- `lib/features/form/application/form/form_state/table_state_notifier.provider.dart`
+- `lib/data/completion_dialog_config.provider.dart`
+- `lib/data/controller.provider.dart`
+- `lib/data/org_unit/ou_picker_data_source.provider.dart`
+- `lib/features/form_submission/application/submission_creation_model.provider.dart`
+- `lib/features/form_submission/presentation/field/date_time_main.dart`
+- `lib/core/sync/sync_coordinator.dart`
+- `lib/core/sync/sync_executor.dart`
+- `lib/core/sync/sync_progress_notifier.dart`
+- `lib/core/sync_manager/sync_service.provider.dart`
+- `packages/drun_sdk/lib/di/injection.config.dart` generated `initActiveSessionContextScope(...)`
+- `packages/drun_sdk/lib/datasource/remote_datasource_order_map.dart`
+- `repeat_instances` table/DAO/datasource
+- `data_values` capture datasource
+- `metadata_submissions` table/datasource
+- `party`/manifest provider and tables, unless a future runtime pass proves production use
+
+## Open Reconciliation Questions
+
+1. Do real production forms contain `ValueType.Reference` fields? If yes, the reference widget path is reachable, but its provider still appears incomplete.
+2. Are `user_form_permissions` ever used for active access decisions, or is `assignment_forms` the only active permission gate?
+3. Can `SyncCoordinator` or `SyncExecutor` be triggered by background work not visible in static route scans?
+4. Does the generated SDK `initActiveSessionContextScope(...)` ever run after code generation or through tests, or is manual `registerUserSdkDeps(...)` the only production path?
+5. Which synced resources are semantically required for current production forms, beyond being registered in the sync loop?
+6. Are Stacked `SnackbarService` or `BottomSheetService` used by any runtime feature outside static Dart references?
+7. Should `sync_summaries` remain a core table, or is it supporting/debug sync telemetry?
+
+## Next Step
+
+Before the next feature/refactor pass, update future maps to use this strict legend from the start. For existing maps, read this document as the label overlay:
+
+- Use `01` mainly for broad entrypoint evidence and candidate surfaces.
+- Use `02` as the strongest static source for active form/repeat/save behavior.
+- Use `03` as the strongest static source for active sync fetch registration, but separate "synced resource" from "core offline consumer."
+- Use `04` for state/DI ownership, with the DialogService correction recorded above.
+
+The next runtime confirmation pass should focus on GetIt scope behavior, datasource registration order, real form JSON value types, repeat UID persistence, and whether supporting tables/providers are actually touched during normal production workflows.

--- a/docs/agent-context/06-large-repeat-hang-data-loss.md
+++ b/docs/agent-context/06-large-repeat-hang-data-loss.md
@@ -1,0 +1,235 @@
+# Large Repeat Hang And Data-Loss Investigation
+
+Generated: 2026-07-10
+
+Scope: active large-repeat performance and possible unsaved-work loss in the current production form flow. This document builds on:
+
+- `02-form-flow.md`
+- `04-state-di-runtime-map.md`
+- `05-classification-reconciliation.md`
+
+This is still pre-refactor mapping. No persistence format change, repeat renderer rewrite, expression-engine rewrite, or data model migration is assumed here.
+
+## Validation Legend
+
+- STATIC-VALIDATED: the code path or bug shape is directly proven by active call sites and implementations.
+- STATIC-PARTIAL: the code proves a risk is possible, but runtime traces are still needed to prove magnitude or that it explains the reported production symptom.
+- RUNTIME-REQUIRED: static evidence is not enough; needs reproduction, profiling, or real data.
+- NOT-FIRST-PR: valid risk, but not a safe first slice because it changes behavior or data semantics too broadly.
+
+Strict active test: this document only treats paths as core-active when commenting/removing them without replacement would break active form load/render/repeat/edit/save or core data collection. Generated, stale, supporting, or form-looking code is not treated as active by name alone.
+
+## Executive Conclusion
+
+The large-repeat hang is probably not one single issue. Static evidence shows a stack of multiplicative costs:
+
+1. Existing repeat rows are loaded eagerly into `reactive_forms` controls.
+2. The app builds a second eager element tree for the same repeat rows.
+3. Dependency resolution and evaluation walk the full tree.
+4. Row edit/save reduces and writes the whole submission JSON.
+5. Some active save calls are not awaited.
+6. Field value subscriptions appear not to be cancelled.
+7. Repeat row UIDs are read and sometimes set, but not written back by the reducer.
+
+The strongest immediate correctness problem is not rendering performance. It is save lifecycle correctness: active UI paths fire `saveFormData()` without awaiting the database write, then can continue to completion/finalization/scope disposal. That is a small, provable bug surface and a better first PR than speculative performance tuning.
+
+## Ranked Hypotheses With Validation
+
+| Rank | Hypothesis | Validation | Evidence | What is proved | What still needs runtime confirmation |
+| --- | --- | --- | --- | --- | --- |
+| 1 | Active save paths can race navigation/finalization/scope disposal because saves are not awaited. | STATIC-VALIDATED for bug shape; STATIC-PARTIAL for production data-loss causality. | `lib/features/form_submission/presentation/form_submission_screen.widget.dart:189-212`, `:249-264`; `lib/features/form_submission/presentation/section/repeat_table.widget.dart:198-206`, `:262-270`; `lib/features/form_submission/application/element/form_instance.dart:85-103`; `packages/drun_sdk/lib/database/dao/data_submissions_dao.dart:198-218`. | `_onSaveForm()` returns before `FormInstance.saveFormData()` finishes. Repeat row save also starts the async save without awaiting it. `dropScope()` and `markFinal()` can run after a non-awaited save has been started. | Whether reported erased work happened through this race, a crash during the write, or both. Need ordered logs: save-start, save-end, mark-final, navigator-pop, drop-scope. |
+| 2 | Opening large repeat submissions is expensive because controls and model rows are built eagerly. | STATIC-VALIDATED. | `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart:103-116`; `lib/core/form/builder/form_element_control_builder.dart:51-58`; `lib/core/form/builder/form_element_builder.dart:79-96`; `lib/features/form_submission/application/element/form_instance.dart:40-47`. | Every initial repeat row becomes a `FormGroup` and a `RepeatItemInstance` before the form screen renders. `FormInstance` then builds an element-path map by iterating the whole tree. | Exact row-count threshold where startup becomes unacceptable on target Android devices. Need timings for 50, 100, 200, 300 rows. |
+| 3 | Initial and triggered expression evaluation scale across all repeat rows. | STATIC-VALIDATED for traversal; STATIC-PARTIAL for performance magnitude. | `form_flow_bootstrapper_vm.dart:115-116`; `lib/features/form_submission/application/element/section_instance.dart:49-75`; `lib/features/form_submission/application/element/repeat_instance.dart:52-78`; `lib/features/form_submission/application/element/form_element.dart:243-288`; `packages/drun_sdk/lib/core/form/rule/action.dart:72-93`; `packages/drun_sdk/lib/core/form/rule/choice_filter.dart:18-27`. | Root bootstrap calls `resolveDependencies()` and `evaluate()`. Section and repeat evaluation recursively evaluate children/rows. Rule expressions are parsed during evaluation. The current `evaluate()` evaluates each rule once for logging and again for apply/reset. | Which real forms have the riskiest dependency graph. Need counts of rules, dependencies, choice filters, evaluations per keystroke/row save, and total eval time. |
+| 4 | Whole-submission JSON save makes one-row edits pay full-form cost. | STATIC-VALIDATED. | `lib/features/form_submission/application/element/form_instance.dart:85-103`; `lib/features/form_submission/application/element/section_instance.dart:129-138`; `lib/features/form_submission/application/element/repeat_instance.dart:101-106`; `packages/drun_sdk/lib/database/tables/data_submissions.table.dart:39-40`; `packages/drun_sdk/lib/database/converters/null_aware_map.converter.dart:16-17`. | Saving reduces the full form tree, merges it into `formData`, JSON-encodes the whole map, and updates one `data_instances.form_data` column. Repeat row save calls the same whole-submission save. | Actual JSON size and DB write time for real 200-300 row submissions. |
+| 5 | Field value subscriptions are likely leaked on rebuild/dispose. | STATIC-VALIDATED for missing cancel call; STATIC-PARTIAL for symptom magnitude. | `lib/features/form_submission/presentation/field/field.widget.dart:28-39`. | `useEffect` listens to `control.valueChanges`; disposer returns `() => subscription`, which does not call `subscription.cancel()`. In a `void Function()` disposer, the returned object is ignored. | How many stale subscriptions accumulate in normal row edit/reopen flows and whether they trigger duplicated `element.updateValue()`/evaluation work. |
+| 6 | Repeat row UID persistence is incomplete and can drop existing row identity. | STATIC-VALIDATED for current reducer behavior; RUNTIME-REQUIRED for server consequence. | `lib/core/form/builder/form_element_builder.dart:65-69`; `lib/features/form_submission/application/element/repeat_item_instance.dart:21-25`, `:43-55`; `lib/features/form_submission/presentation/section/edit_row_screen.dart:183-185`; `lib/features/form_submission/presentation/section/repeat_table.widget.dart:327-329`; `lib/features/form_submission/application/element/form_instance.dart:85-103`. | Existing `repeatUid` is read from row JSON. Some close-confirm paths can set a new UID. But `RepeatItemInstance.reduceValue()` has `repeatUid` writeback commented out, and `createSectionFormGroup()` only builds controls from template children. Saving replaces the repeat list with reduced row maps, so `repeatUid` is not preserved by the active reducer. | Server behavior when a synced submission with repeat rows is edited and re-uploaded without stable row UIDs. Needs real payload/reopen/upload test. |
+| 7 | Paginated repeat table reduces visible rows but not load/save/model cost. | STATIC-VALIDATED. | `lib/features/form_submission/presentation/section/repeat_table.widget.dart:68-74`, `:104-144`; `lib/features/form_submission/presentation/section/repeat_table_rows_source.dart:15-23`, `:62-78`, `:209-216`. | `RepeatTableDataSource` stores all repeat items. `rowCount` is the full list. `getRow()` builds visible row cells by walking that row's fields. Pagination does not make bootstrap, dependency resolution, save, or memory lazy. | How many `getRow()` calls happen per update on target Flutter/DataTable behavior. |
+| 8 | Repeated dependency lookup can become expensive or resolve ambiguously. | STATIC-PARTIAL. | `lib/features/form_submission/application/element/element_dependency.extension.dart:77-108`. | Dependency resolution searches parent sections first, then falls back to walking the whole tree. This can be costly for unresolved or global dependencies, and risky with repeated field names. | Whether real repeat expressions resolve row-local fields correctly in nested repeats and how often fallback tree walking occurs. |
+| 9 | Form scope disposal can destroy the only complete in-memory state while save is still in flight. | STATIC-PARTIAL. | `form_flow_bootstrapper_vm.dart:57-69`, `:80-83`; `form_submission_screen.widget.dart:196-201`, `:249-264`; `04-state-di-runtime-map.md` form scope section. | Form state lives in a per-submission GetIt scope. Completion paths drop that scope. Combined with unawaited saves, this is a credible unsaved-work loss path. | Actual GetIt disposal timing and whether `FormInstance` remains reachable after route pop/drop-scope in current navigation stack. |
+| 10 | Client memory pressure is likely with 200-300 rows. | STATIC-PARTIAL. | Same evidence as eager control/model build plus `FieldWidget` subscriptions and full tree maps. | The code creates many controls, instances, streams, keys, and subscriptions. Cost scales with rows times fields. | Heap/GC measurements on target devices. |
+
+## Files And Functions To Inspect First
+
+### Save Correctness
+
+- `lib/features/form_submission/presentation/form_submission_screen.widget.dart`
+  - `_saveAndShowBottomSheet`
+  - `_onSaveForm`
+  - `_onCompletionDialogButtonClicked`
+  - `backButtonPressed`
+- `lib/features/form_submission/presentation/section/repeat_table.widget.dart`
+  - `_showEditPanel`
+  - `showEditDialog`
+  - `_handleSave`
+- `lib/features/form_submission/application/element/form_instance.dart`
+  - `saveFormData`
+  - `markSubmissionAsFinal`
+- `packages/drun_sdk/lib/database/dao/data_submissions_dao.dart`
+  - `updateData`
+  - `markFinal`
+
+Why first: this is the only area where static evidence already proves a correctness bug shape. It can explain lost work even if performance remains bad.
+
+### Large Repeat Performance
+
+- `lib/core/form/builder/form_element_control_builder.dart`
+  - `createRepeatFormArray`
+  - `createSectionFormGroup`
+- `lib/core/form/builder/form_element_builder.dart`
+  - `buildRepeatInstance`
+  - `buildRepeatItem`
+- `lib/features/form_submission/application/element/section_instance.dart`
+  - `resolveDependencies`
+  - `evaluate`
+  - `reduceValue`
+- `lib/features/form_submission/application/element/repeat_instance.dart`
+  - `resolveDependencies`
+  - `evaluate`
+  - `reduceValue`
+- `lib/features/form_submission/application/element/form_element.dart`
+  - `evaluate`
+  - `resolveDependencies`
+- `lib/features/form_submission/application/element/element_dependency.extension.dart`
+  - `evalContext`
+  - `notifySubscribers`
+  - `findElementInParentSection`
+
+Why second: this proves where the hang likely comes from, but the safe fix is not obvious without trace data.
+
+### Repeat UID
+
+- `lib/features/form_submission/application/element/repeat_item_instance.dart`
+  - `uid`
+  - `setUid`
+  - `reduceValue`
+- `lib/core/form/builder/form_element_builder.dart`
+  - `buildRepeatItem`
+- `lib/features/form_submission/presentation/section/edit_row_screen.dart`
+  - `_onTryToClose`
+- `lib/features/form_submission/presentation/section/repeat_table.widget.dart`
+  - `_onTryToClose`
+- `packages/drun_sdk/lib/database/extensions/data_submission.extension.dart`
+  - `toUpload`
+
+Why separate: persisting repeat UIDs changes saved JSON semantics and may affect server update matching. It should not be bundled into the first safety PR.
+
+## Runtime Measurements Needed
+
+Use a real or generated copy of the large activity form with 50, 100, 200, and 300 repeat rows.
+
+| Measurement | Confirms/rejects | Where to instrument |
+| --- | --- | --- |
+| Bootstrap phase timings: draft/template load, control build, element build, dependency resolve, initial evaluate, `FormInstance` map build, first frame. | Whether hang is mainly open-time eager build/evaluate. | `FormFlowBootstrapperVm._formInstance`, `FormInstance` constructor. |
+| Counts: repeat sections, rows per repeat, fields per row, total controls, total element instances, total rules, total dependency edges. | Whether cost matches row-count growth. | Builders and dependency resolution. |
+| Evaluation counters: number of `evaluate()` calls, rule evaluations, choice-filter evaluations, fallback tree walks. | Whether expression-heavy forms are worse because evaluation cascades. | `FormElementInstance.evaluate`, `ChoiceFilter.evaluate`, `findElementInParentSection`. |
+| Save timings: reduce time, JSON byte length, JSON encode time, DB update time, total save time. | Whether row edits block on whole-form JSON persistence. | `FormInstance.saveFormData`, `NullAwareMapConverter.requireToSql`, `DataInstancesDao.updateData`. |
+| Save ordering trace: save-start, save-end, save-error, row-screen pop, bottom-sheet open, mark-final, drop-scope. | Whether unawaited save races exist in real interaction. | Form screen and repeat row save handlers. |
+| Subscription count per field/control after opening and closing row edit 10-20 times. | Whether `FieldWidget` leaks listeners. | `FieldWidget` effect/dispose trace. |
+| UID persistence trace: row UID before save, saved DB JSON, reopened row UID, upload payload. | Whether repeat UIDs are dropped and whether server update sees stable row identity. | `RepeatItemInstance.reduceValue`, `saveFormData`, `toUpload`. |
+| Memory/GC snapshots before open, after open, after editing rows, after close/reopen. | Whether memory pressure contributes to hangs or process death. | Flutter DevTools/profile build on device. |
+
+## Minimal Safety Improvements
+
+These are not structural optimizations. They are guardrails to reduce data loss while collecting proof.
+
+1. Await every active `saveFormData()` call before row close, bottom sheet display, finalization, navigation pop, or scope drop.
+2. Add an in-flight save guard so concurrent taps or row saves cannot run overlapping whole-submission writes.
+3. Return or surface save failures and block `dropScope()`/`markFinal()` when the save fails.
+4. Add timing and size traces around save reduction, JSON encoding, and DB update.
+5. Log repeat row count and JSON size at save time.
+6. Do not change the persistence format in this PR.
+7. Do not persist `repeatUid` in this PR unless a separate runtime test proves the server contract and expected JSON shape.
+
+## First PR Slice Evaluation
+
+### Candidate PR
+
+Title: `Guard and trace submission saves`
+
+Primary files:
+
+- `lib/features/form_submission/presentation/form_submission_screen.widget.dart`
+- `lib/features/form_submission/presentation/section/repeat_table.widget.dart`
+- `lib/features/form_submission/application/element/form_instance.dart`
+
+Possible supporting file only if needed:
+
+- a small trace helper, or existing logger calls directly if a helper would add noise.
+
+### Why This Is Not A Scam Slice
+
+This PR fixes a statically proven correctness issue: active save callers do not await the asynchronous DB write. That is independently valuable even if large-repeat rendering remains slow.
+
+It is also measurable:
+
+- Before/after ordered logs can show whether bottom sheet/finalization/scope disposal happens before or after save completion.
+- Save duration and JSON size logs give the first real numbers for 50/100/200/300 repeat rows.
+- Manual reproduction can verify that repeated save taps do not create overlapping writes.
+- Reopening the submission after save can confirm the latest row count survived.
+
+It is small and reversible:
+
+- No data schema change.
+- No server contract change.
+- No repeat rendering rewrite.
+- No expression dependency rewrite.
+- No migration.
+
+### Minimum Acceptance Criteria
+
+The PR should be rejected as too weak if it only adds logs. It must include the save lifecycle fix.
+
+The PR should be rejected as too broad if it includes repeat virtualization, dependency graph rewrites, UID persistence, or JSON format changes.
+
+Done means:
+
+1. All active save call sites await save completion.
+2. A save-in-flight guard prevents concurrent whole-form writes for the same `FormInstance`.
+3. `markFinal` and `dropScope` are not reached after a failed save.
+4. Trace logs include row count, reduce time, DB update time, and total save time.
+5. A manual test path is documented for a 50-row and 200-row submission.
+
+### Why Not Start With Other Fixes
+
+| Alternative first PR | Decision | Reason |
+| --- | --- | --- |
+| Repeat rendering virtualization/lazy row model | NOT-FIRST-PR | Probably necessary later, but too structural before measurements. It risks changing UI behavior without first proving the slow phase. |
+| Expression engine caching/rewrite | NOT-FIRST-PR | The active evaluation path is risky, but changing dependency semantics before traces could break form rules. |
+| Persist `repeatUid` in `reduceValue()` | NOT-FIRST-PR | Static evidence says persistence is incomplete, but this changes saved JSON and server update semantics. Needs a focused UID runtime test first. |
+| Replace whole JSON persistence | NOT-FIRST-PR | Too large and explicitly outside current constraints. |
+| Instrumentation-only PR | Reject | It measures but does not fix the proven unawaited-save race. |
+| Save lifecycle guard plus traces | Accept | Fixes a real correctness bug and gives the minimum measurements needed for the next performance PR. |
+
+## Runtime Confirmation Questions
+
+1. Does a row edit save complete before the edit screen pops in current production behavior?
+2. Can `MarkAsFinal` run before the previous save write has finished?
+3. After a hang or forced process kill during/after save, is the last edited row present in `data_instances.formData`?
+4. How long does `formSection.value` take for 50, 100, 200, and 300 repeat rows?
+5. How large is the encoded `formData` JSON at those row counts?
+6. How many `evaluate()` calls happen when editing one field inside a repeat row?
+7. Does opening and closing repeat row edit screens increase active `valueChanges` listeners?
+8. Does a server-submitted repeat row keep its original `repeatUid` after load, save, reopen, and upload?
+9. Are forms with more rules slower because of rule count, dependency fallback walks, choice filters, or save size?
+10. On target Android devices, does memory rise enough at 200-300 rows to trigger process death or OS pressure?
+
+## Carry-Forward Risk Map
+
+| Area | Current label | Carry-forward action |
+| --- | --- | --- |
+| Unawaited save calls | STATIC-VALIDATED | First PR should fix and trace. |
+| Eager repeat control/model build | STATIC-VALIDATED | Profile after save guard; likely second performance PR area. |
+| Whole-submission JSON save | STATIC-VALIDATED | Measure first; structural changes later only if approved. |
+| Expression/repeat evaluation cost | STATIC-PARTIAL | Add counters/timings before changing semantics. |
+| Field subscription cleanup | STATIC-VALIDATED for missing cancel | Candidate small correctness fix, but can be separate from save guard if it risks widget lifecycle changes. |
+| Repeat UID persistence | STATIC-VALIDATED for missing reducer writeback | Dedicated runtime test and server-contract decision before code change. |
+| Memory pressure | STATIC-PARTIAL | Needs profile-mode device measurements. |
+
+## Next Investigation Step
+
+Do the first PR as a safety-and-measurement slice only if it includes the awaited-save fix. After that PR, run a controlled large-repeat test and use the trace output to decide the next slice:
+
+1. If bootstrap dominates, investigate lazy repeat control/model construction.
+2. If evaluation dominates, investigate dependency resolution and expression evaluation counters.
+3. If save dominates, investigate save reduction/JSON encode/DB write strategy.
+4. If UID loss is reproduced, plan a separate repeat UID contract PR with server payload examples.

--- a/docs/agent-context/07-repeat-uid-contract.md
+++ b/docs/agent-context/07-repeat-uid-contract.md
@@ -1,0 +1,156 @@
+# Repeat UID Behavior Contract
+
+Generated: 2026-07-10
+
+Scope: define the intended behavior for repeat item UIDs before implementing anything. This document uses active code paths as authority and treats earlier docs/comments/table names as evidence only.
+
+Related maps:
+
+- `02-form-flow.md`
+- `05-classification-reconciliation.md`
+- `06-large-repeat-hang-data-loss.md`
+
+## Proposed Contract
+
+Repeat item UID behavior should be:
+
+1. Each repeat item has a client-generated `repeatUid`.
+2. New repeat rows created on the client receive a `repeatUid` before they are persisted into submission JSON.
+3. Existing repeat rows loaded for edit preserve their existing `repeatUid`.
+4. A non-null repeat item UID is immutable in memory; later edits must not overwrite it.
+5. Submission save/upload uses the `repeatUid` stored inside the whole `formData` JSON.
+6. The implementation must not depend on inactive-looking `repeat_instances`, `data_values`, or old form-state/provider paths.
+7. Missing `repeatUid` on legacy/existing row JSON should be treated as "needs client UID assignment on next save", not as a reason to use row index as identity.
+
+This contract keeps repeat identity local to the active whole-submission JSON flow. It does not introduce normalized repeat-row persistence.
+
+## Current Active Flow
+
+| Question | Current code path | Evidence | Current behavior |
+| --- | --- | --- | --- |
+| Where repeat rows are loaded for editing | `FormFlowBootstrapperVm._formInstance` reads `DataInstance.formData`, builds controls, then builds element instances. | `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart:92-116` | Existing saved JSON is loaded all at once. Repeat rows are not loaded from a separate repeat table. |
+| Where repeat controls are loaded | `FormElementControlBuilder.createRepeatFormArray` maps each existing repeat row JSON item into a `FormGroup`. | `lib/core/form/builder/form_element_control_builder.dart:51-58` | The reactive controls are built from template children. `repeatUid` is not a template child, so it is not represented as a form control. |
+| Where repeat row models are loaded | `FormElementBuilder.buildRepeatInstance` maps each row into `buildRepeatItem`; `buildRepeatItem` passes `initialFormValue?['repeatUid']` into `RepeatItemInstance`. | `lib/core/form/builder/form_element_builder.dart:60-96` | Existing `repeatUid` can be preserved in the in-memory repeat item model if it exists in row JSON. |
+| Where new repeat rows are created | `RepeatTable` add action calls `FormInstance.onAddRepeatedItem`; save-and-add-another also calls `onAddRepeatedItem`. | `lib/features/form_submission/presentation/section/repeat_table.widget.dart:112-120`, `:294-297`; `lib/features/form_submission/application/element/form_instance.dart:134-150` | New rows are created with no `initialFormValue`, so `RepeatItemInstance.uid` starts as null. |
+| Where repeat rows are edited | `RepeatTable._showEditPanel` navigates to `EditRowScreen` using the existing `RepeatItemInstance`. | `lib/features/form_submission/presentation/section/repeat_table.widget.dart:177-211`; `lib/features/form_submission/presentation/section/edit_row_screen.dart:17-32` | Edit uses the current row model/control. Existing row UID is available through `RepeatItemInstance.uid` if it was loaded. |
+| Where UID is currently generated | Close-confirm save paths call `repeatItem.setUid(CodeGenerator.generateUid())` when `uid == null`. | `lib/features/form_submission/presentation/section/edit_row_screen.dart:161-185`; `lib/features/form_submission/presentation/section/repeat_table.widget.dart:304-329` | UID generation is UI-path dependent. Normal row save buttons do not obviously set UID before `saveFormData()`. |
+| Where UID overwrite is prevented | `RepeatItemInstance.setUid` throws if `_uid` is already non-null. | `lib/features/form_submission/application/element/repeat_item_instance.dart:21-25` | In-memory overwrite protection exists, but only for callers using `setUid`. |
+| Where repeat rows are serialized | `FormInstance.saveFormData` reads `formSection.value`; `Section.reduceValue`, `RepeatSection.reduceValue`, and `RepeatItemInstance.reduceValue` produce the nested map/list. | `lib/features/form_submission/application/element/form_instance.dart:85-103`; `lib/features/form_submission/application/element/section_instance.dart:129-138`; `lib/features/form_submission/application/element/repeat_instance.dart:101-106`; `lib/features/form_submission/application/element/repeat_item_instance.dart:43-55` | `RepeatItemInstance.reduceValue` currently does not write `repeatUid`; the line that would write it is commented out. |
+| Where saved JSON is persisted | `DataInstancesDao.updateData` writes `formData` into `data_instances.form_data`. | `packages/drun_sdk/lib/database/dao/data_submissions_dao.dart:198-208` | The active persistence unit is one whole submission JSON object. |
+| Where upload payload reads repeat rows | `DataSubmissionUploadExt.toUpload` includes `formData` directly. | `packages/drun_sdk/lib/database/extensions/data_submission.extension.dart:3-23`; `packages/drun_sdk/lib/database/dao/data_submissions_dao.dart:68` | Upload uses whatever repeat row JSON was saved. It does not add repeat UIDs later. |
+
+## Current New Submission Vs Edit Behavior
+
+| Flow | Current behavior | Contract gap |
+| --- | --- | --- |
+| New submission, new repeat row, normal row save | Row is created with `uid == null`; active row save calls `formInstance.saveFormData()` but does not set UID first. | The saved row can be missing `repeatUid`. |
+| New submission, new repeat row, close-confirm save | `_onTryToClose` can set a UID before closing if user chooses save-and-close from the warning dialog. | UID assignment depends on a specific close path, not the canonical save path. |
+| Existing draft/synced submission, row has `repeatUid` in JSON | `buildRepeatItem` reads it into `RepeatItemInstance.uid`; `setUid` would reject overwrite. | The next save can still drop it because `reduceValue` does not serialize it. |
+| Existing draft/synced submission, row lacks `repeatUid` in JSON | Row loads with `uid == null`; close paths treat it as new. | Legacy rows need UID assignment on next save, but the app should not treat row index as stable identity. |
+| Upload after edit | Upload sends saved `formData`. | If save dropped UID, upload cannot recover it. |
+
+## Active/Inert Boundary
+
+UID implementation should stay in the active whole-JSON path:
+
+- `RepeatItemInstance`
+- `FormElementBuilder`
+- `FormInstance.saveFormData`
+- `DataInstancesDao.updateData`
+- `DataSubmissionUploadExt.toUpload`
+
+Do not base the UID contract on these inactive or legacy-risk paths unless a later runtime pass proves they are active:
+
+- `packages/drun_sdk/lib/database/tables/repeat_instances.table.dart`
+- `packages/drun_sdk/lib/database/dao/repeat_instances_dao.dart`
+- `packages/drun_sdk/lib/datasource/remote_data_sources/repeat_instance_datasource.dart`
+- `packages/drun_sdk/lib/database/tables/data_values.table.dart` as capture storage
+- `lib/core/element_instance/form_state.provider.dart`
+- `lib/features/form_submission/application/form_instance.provider.dart`
+- `lib/core/form/data/form_repository_impl.dart`
+
+## Impacted Files
+
+Must understand before implementation:
+
+- `lib/features/form_submission/application/element/repeat_item_instance.dart`
+- `lib/core/form/builder/form_element_builder.dart`
+- `lib/features/form_submission/application/element/repeat_instance.dart`
+- `lib/features/form_submission/application/element/section_instance.dart`
+- `lib/features/form_submission/application/element/form_instance.dart`
+- `lib/features/form_submission/presentation/section/repeat_table.widget.dart`
+- `lib/features/form_submission/presentation/section/edit_row_screen.dart`
+- `packages/drun_sdk/lib/database/dao/data_submissions_dao.dart`
+- `packages/drun_sdk/lib/database/extensions/data_submission.extension.dart`
+
+Likely test/smoke support:
+
+- active example forms under `example/`
+- any existing form submission tests if present
+- a manual DB inspection path for `data_instances.form_data`
+
+## Minimal Implementation Plan
+
+Do not implement in the docs pass. Proposed smallest code change later:
+
+1. Add an explicit `ensureUid()` method to `RepeatItemInstance`.
+   - If `_uid` is null, assign `CodeGenerator.generateUid()`.
+   - If `_uid` is non-null, return it unchanged.
+2. Make `RepeatItemInstance.reduceValue()` serialize `repeatUid`.
+   - Use `map['repeatUid'] = ensureUid();`
+   - Keep existing field serialization unchanged.
+3. Keep `setUid` immutability behavior.
+   - It should still throw if callers try to overwrite an existing UID.
+4. Avoid moving UID generation into `onAddRepeatedItem` unless the close-without-saving UX is adjusted.
+   - Current close-warning logic uses `uid == null` to identify unsaved new rows.
+   - Generating UID at add time would accidentally make new unsaved rows look existing.
+5. Leave inactive repeat/data-value tables untouched.
+6. After this contract is implemented, consider whether UI close-confirm `setUid(...)` calls are redundant, but do not remove them in the same minimal change unless tests prove the flow is unchanged.
+
+Why this is minimal:
+
+- Existing rows keep their loaded UID because `ensureUid()` uses null-coalescing assignment.
+- New rows get a UID at the point they are serialized for actual save.
+- Saved JSON gains `repeatUid` in the same active whole-submission persistence path.
+- No DB schema change is required.
+- No server upload code changes are required if server already consumes `formData`.
+
+## Acceptance Criteria
+
+Behavioral:
+
+1. A newly added repeat row saved through the normal row save button has `repeatUid` in `data_instances.form_data`.
+2. A newly added repeat row saved through save-and-add-another has `repeatUid` in `data_instances.form_data`.
+3. An existing repeat row loaded with `repeatUid` keeps the exact same UID after edit/save/reopen.
+4. An existing repeat row loaded without `repeatUid` receives one on next save.
+5. Editing an existing row never replaces a non-null `repeatUid`.
+6. Upload payload includes repeat rows with the saved `repeatUid` because `toUpload()` sends `formData`.
+7. No `repeat_instances` or `data_values` capture path is introduced.
+
+Code-level:
+
+1. `RepeatItemInstance.reduceValue()` includes `repeatUid`.
+2. UID assignment is centralized in the repeat item model, not scattered through UI save buttons.
+3. Existing `setUid` overwrite protection remains.
+4. The change is independent of the await-save fix, although the await-save fix should land first for save correctness.
+
+Smoke checks:
+
+1. Create a new submission with one repeat row, save, reopen, confirm `repeatUid` exists and is stable.
+2. Add two repeat rows, save-and-add-another, reopen, confirm each row has a distinct `repeatUid`.
+3. Edit a saved repeat row, save, reopen, confirm UID did not change.
+4. Import or seed a submission with a repeat row containing `repeatUid`, edit it, save, inspect DB JSON, confirm same UID.
+5. Seed a legacy row without `repeatUid`, save, inspect DB JSON, confirm a UID was added.
+6. Build upload payload for a finalized submission and confirm nested repeat rows include `repeatUid`.
+
+## Ordering With Other Work
+
+Recommended order:
+
+1. Tooling baseline on `develop`.
+2. Docs PR containing this contract.
+3. `fix/await-form-save` PR.
+4. Repeat UID implementation PR.
+5. Large-repeat performance measurement/refactor PRs.
+
+Reason: UID persistence depends on save correctness. If saves can still race navigation or scope disposal, UID behavior tests may produce misleading failures.

--- a/docs/agent-context/08-validation-baseline.md
+++ b/docs/agent-context/08-validation-baseline.md
@@ -1,0 +1,75 @@
+# Validation Baseline Before Refactoring
+
+Generated: 2026-07-10
+
+Scope: smallest practical check baseline for future PRs. This is not a test strategy rewrite and does not change runtime behavior.
+
+## Bottom Line
+
+The current usable baseline is:
+
+1. `flutter pub get` must pass.
+2. `flutter build apk --debug` must pass for code changes that can affect runtime/build behavior.
+3. `flutter analyze` must be run and reported, but it is currently red.
+4. `flutter test` must be run and reported, but it is currently red because the discovered tests are stale/commented out.
+
+Do not treat the current test suite as coverage for production form behavior.
+
+## Command Matrix
+
+| Area | Command | Status on 2026-07-10 | Evidence / notes |
+| --- | --- | --- | --- |
+| Toolchain | `flutter --version` | PASS | Flutter 3.41.9 stable, Dart 3.11.5. In this sandbox it needed access to the FVM cache outside the repo. |
+| Dependency resolution | `flutter pub get` | PASS | Root app resolves. Reports 73 newer packages outside constraints; this is not a failure. |
+| Static analysis | `flutter analyze` | FAIL | 50 issues. Mostly unused/unnecessary imports, deprecated API use, `sort_constructors_first`, and experimental Sentry API warning. Includes app and `packages/drun_sdk`. |
+| Root tests | `flutter test` | FAIL | Both discovered test files fail to load because they have no active `main()` method. |
+| Debug Android build | `flutter build apk --debug` | PASS | Produces `build/app/outputs/flutter-apk/app-debug.apk`. |
+| Code generation | `dart run build_runner build --delete-conflicting-outputs` | AVAILABLE, NOT RUN | Generator command is discoverable from dev dependencies but rewrites generated files, so do not run as a read-only baseline. Run only in PRs that intentionally touch generated code. |
+| SDK tests | `cd packages/drun_sdk && dart test` | UNAVAILABLE / NOT BASELINE | No `packages/drun_sdk/test` directory found. SDK `flutter_test` dev dependency is commented out. Root `flutter analyze` still analyzes SDK code. |
+| Release build | `flutter build apk --release` | NOT BASELINE | Release signing intentionally requires valid local `android/key.properties`; do not use this as normal PR validation until signing is configured on the machine/CI. |
+
+## Broken Or Outdated Tests Found
+
+| File | Status | Why it matters |
+| --- | --- | --- |
+| `test/widget_test.dart` | Outdated/commented | Counter-template test is commented out and does not exercise this app. `flutter test` reports missing `main()`. |
+| `test/get_it_test/get_it_test.dart` | Outdated/commented | Old GetIt/reflectable experiments are commented and reference stale packages/imports. `flutter test` reports missing `main()`. |
+| `packages/drun_sdk/test/` | Missing | SDK has no separate test surface despite containing active parsing, persistence, and sync code. |
+
+## Minimal Validation Strategy
+
+Until real characterization tests exist, future code PRs should use this baseline:
+
+| PR type | Required checks | How to read the result |
+| --- | --- | --- |
+| Docs-only | Verify diff is docs-only. Runtime checks optional. | No app behavior changed. |
+| Tooling/build config | `flutter pub get`, `flutter build apk --debug` | Both should pass before merge. |
+| Runtime app or SDK code | `flutter pub get`, `flutter analyze`, `flutter test`, `flutter build apk --debug` | Build must pass. Analyze/test failures must be reported and should not get worse. |
+| Generated-code PR | `dart run build_runner build --delete-conflicting-outputs`, then normal runtime checks | Generated diffs must be intentional and reviewed. |
+| Form/save/repeat PR | Normal runtime checks plus targeted characterization tests once added | Do not rely on current stale tests as proof. |
+
+The first cleanup target should not be "fix all tests." The practical target is to add a few focused tests around active behavior, then make `flutter test` meaningful again.
+
+## First Characterization Test PR Recommendation
+
+Create a small test PR before deeper form refactoring. Keep it focused on active behavior:
+
+1. Repeat UID preservation test.
+   - Prove an existing repeat row UID loaded from JSON is preserved after reduce/save behavior.
+   - Prove a new repeat row receives a UID before persistence.
+   - Target active files: `repeat_item_instance.dart`, `repeat_instance.dart`, and the active builder/reducer path.
+
+2. Submission save characterization.
+   - Prove `FormInstance.saveFormData()` awaits the DAO write and persists the whole `formData` JSON expected by upload.
+   - Prefer a fake/in-memory DAO seam only if the current code already supports it; do not introduce a large test framework.
+
+3. Form JSON loading smoke test.
+   - Use a small fixture modeled after `example/` forms.
+   - Prove loading creates repeat controls/items from whole JSON rather than inactive `repeat_instances` or `data_values` tables.
+
+Acceptance for that test PR:
+
+- `flutter test` runs at least one real active-behavior test.
+- Old commented tests are either removed or replaced in the same small PR.
+- No production behavior changes unless the PR is explicitly paired with a tiny bug fix.
+- No new persistence format or refactor is introduced.

--- a/docs/agent-context/agents-onboarding.md
+++ b/docs/agent-context/agents-onboarding.md
@@ -1,0 +1,263 @@
+# Agent Onboarding
+
+Generated: 2026-07-10
+
+Purpose: give future AI agents enough stable repository context to avoid repeating the same discovery work, misclassifying dead code as active, or making broad changes before the active production paths are understood.
+
+This file is an onboarding guide. The numbered files in `docs/agent-context/` are the evidence maps.
+
+## Repository Purpose
+
+This repo contains the DataRun mobile/data-collection app and the SDK code used by the app. It is a Flutter application for offline-capable field data collection, assignment-driven form access, local form entry, local submission storage, and sync/upload.
+
+The app and SDK live in one repository here, even though the SDK is conceptually a module and may also exist remotely. Current production behavior should be judged from this repo's active runtime paths.
+
+## Production Status
+
+Treat this as a messy production repository for a running app. There is stale documentation, dead code, incomplete feature work, repeated logic, generated code churn, and multiple state-management approaches.
+
+Do not assume an implementation is active because its name sounds right. Some tables and files look form-related but are not part of the active form capture path.
+
+## App Vs SDK Boundary
+
+App code lives mainly under `lib/`.
+
+SDK code lives under `packages/drun_sdk/lib/`.
+
+Important boundary points:
+
+- `lib/main.dart` starts the production app.
+- app DI is configured from `lib/app/di/injection.dart` and generated `lib/app/di/injection.config.dart`.
+- Stacked routing is generated from `lib/app/stacked/app.dart`.
+- the app opens a user-scoped SDK database and registers active SDK datasources after login/session restore.
+- active SDK sync/data persistence goes through `packages/drun_sdk/lib/database`, `packages/drun_sdk/lib/datasource`, and the active datasource list in `packages/drun_sdk/lib/di/init_active_session_scope.dart`.
+- active form rendering uses app-side builders/models and SDK-stored form template JSON.
+
+Do not edit SDK-looking code just because a form feature sounds related. First prove the active app path reaches it.
+
+## Known Messy Areas
+
+- Riverpod, Stacked viewmodels, GetIt scopes, `reactive_forms`, `ChangeNotifier`, generated injectable registrations, and generated providers coexist.
+- Form state is not owned by one clean system.
+- Generated files are significant and can be stale or noisy.
+- There are old router, form-state, form-value, sync, data-value, repeat-instance, metadata-submission, and party/manifest paths that are not proven active for current form capture.
+- Example forms live under `example/`, but examples are evidence only, not production truth.
+
+## Existing Context Maps
+
+Read these before touching related areas:
+
+- `01-production-code-path-map.md`: broad first-pass production path map.
+- `02-form-flow.md`: active/inactive form load, render, repeat, save, edit, UID, and local persistence map.
+- `03-config-fetching.md`: server config/form/assignment/org-unit/metadata fetch and offline cache map.
+- `04-state-di-runtime-map.md`: state management, DI, scopes, generated registration, and runtime ownership map.
+- `05-classification-reconciliation.md`: strict active/inactive classification overlay. Use this legend.
+- `06-large-repeat-hang-data-loss.md`: large repeat hang and save/data-loss risk investigation.
+- `07-repeat-uid-contract.md`: repeat UID behavior contract and planned minimal implementation.
+
+## Active Form Flow Map
+
+Current active form entry/edit flow:
+
+1. Form open/create routes go through Stacked navigation into `FormFlowBootstrapper`.
+2. `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart` creates or loads a `DataInstance`.
+3. It creates a per-submission GetIt scope.
+4. It registers a `FormTemplateRepository`.
+5. It builds the full `reactive_forms` `FormGroup` through `FormElementControlBuilder`.
+6. It builds the full app-side form element tree through `FormElementBuilder`.
+7. It wraps the tree in a root `Section`, resolves dependencies, evaluates rules, and registers `FormInstance`.
+8. `FormSubmissionScreen` renders the active form using scoped `FormInstance`.
+9. Sections render through `SectionWidget`.
+10. Fields render through `FieldWidget` and `FieldFactory`.
+11. Repeats render through `RepeatTableSliver`, `RepeatTable`, and `RepeatTableDataSource`.
+12. Submission save calls `FormInstance.saveFormData()`.
+13. `saveFormData()` reduces the whole form tree to one nested map and writes `data_instances.formData` through `DataInstancesDao.updateData`.
+14. Upload sends that whole saved `formData` through `DataSubmissionUploadExt.toUpload()`.
+
+Core active files:
+
+- `lib/features/form_submission/presentation/form_flow_bootstrapper_vm.dart`
+- `lib/data/form_template_repository.dart`
+- `lib/core/form/builder/form_element_control_builder.dart`
+- `lib/core/form/builder/form_element_builder.dart`
+- `lib/features/form_submission/application/element/form_instance.dart`
+- `lib/features/form_submission/application/element/form_element.dart`
+- `lib/features/form_submission/application/element/section_instance.dart`
+- `lib/features/form_submission/application/element/repeat_instance.dart`
+- `lib/features/form_submission/application/element/repeat_item_instance.dart`
+- `lib/features/form_submission/application/element/field_instance.dart`
+- `lib/features/form_submission/presentation/form_submission_screen.widget.dart`
+- `lib/features/form_submission/presentation/section/repeat_table.widget.dart`
+- `lib/features/form_submission/presentation/section/repeat_table_rows_source.dart`
+- `lib/features/form_submission/presentation/section/edit_row_screen.dart`
+- `packages/drun_sdk/lib/database/dao/data_submissions_dao.dart`
+- `packages/drun_sdk/lib/database/tables/data_submissions.table.dart`
+- `packages/drun_sdk/lib/database/extensions/data_submission.extension.dart`
+
+## Known Inactive Or Incomplete Form-Related Areas
+
+Treat these as inactive, incomplete, or legacy-risk unless runtime evidence proves otherwise:
+
+- `lib/features/form_submission/application/form_instance.provider.dart`
+- `lib/features/form_submission/application/element/form_element_instance.provider.dart`
+- `lib/core/element_instance/form_state.provider.dart`
+- `lib/core/form/data/form_repository_impl.dart`
+- `lib/core/form/data/form_value_store.dart`
+- `lib/features/form_submission/application/repository/submission_capture_repository_impl.dart`
+- `packages/drun_sdk/lib/database/tables/repeat_instances.table.dart`
+- `packages/drun_sdk/lib/database/dao/repeat_instances_dao.dart`
+- `packages/drun_sdk/lib/datasource/remote_data_sources/repeat_instance_datasource.dart`
+- `packages/drun_sdk/lib/database/tables/data_values.table.dart` as active capture storage
+- `packages/drun_sdk/lib/datasource/remote_data_sources/data_value_datasource.dart`
+- `packages/drun_sdk/lib/database/tables/metadata_submissions.table.dart`
+- old `go_router` files under `lib/app/app_routes/`
+
+These files may contain useful ideas or stale design intent, but they are not authority for current behavior.
+
+## Docs Are Evidence, Not Authority
+
+Docs are a map of what previous scans found. They can be wrong or incomplete after code changes.
+
+When docs conflict with code:
+
+1. prefer active runtime call paths;
+2. prefer entrypoints, routes, active DI registrations, imports, and direct references;
+3. prefer currently generated code only when the generated code is actually used by active runtime;
+4. explicitly record uncertainty;
+5. update the docs if a later pass proves an assumption wrong.
+
+## Build, Run, And Check Commands
+
+Known useful commands:
+
+```bash
+flutter pub get
+flutter run
+flutter build apk --debug
+flutter analyze
+flutter test
+dart run build_runner build --delete-conflicting-outputs
+```
+
+Notes:
+
+- `flutter build apk --debug` succeeded on `chore/tooling-compat` with Flutter `3.41.9` and Dart `3.11.5`; that branch was merged into `develop` as the build baseline.
+- Release builds may involve signing and `android/key.properties`; do not change signing casually.
+- Generated code is present. If a change affects Riverpod, Stacked, injectable, Drift, Freezed, JSON serialization, or localization, identify the correct generation command before editing generated files manually.
+- If a command fails because dependencies or SDK caches need network or writes outside the workspace, report that clearly.
+
+## Active Vs Inactive Classification
+
+Use the strict comment-out test from `05-classification-reconciliation.md`:
+
+- ACTIVE: removing the path without replacement would break startup/auth/navigation, sync/offline cache, assignment/form access, form load/render/repeat/edit/save, or submission table behavior.
+- SUPPORTING-USED: reachable UI/helper behavior, but core data collection would still run if intentionally removed.
+- INACTIVE: not referenced by active runtime flow found in static scans.
+- INCOMPLETE: reachable or plausible code exists, but implementation is unfinished, placeholder-based, or returns empty/no-op data.
+- LEGACY-RISK: old, duplicate, registered-only, generated-only, or conceptually related code that could be mistaken for active.
+- UNKNOWN: static evidence cannot prove either way.
+
+Do not classify code as ACTIVE merely because:
+
+- it compiles;
+- it is generated;
+- it is registered in DI but not retrieved by active flow;
+- it has a form/table/repeat-looking name;
+- it appears in stale docs/comments;
+- it is reachable only through commented code.
+
+## Safe Working Rules For Agents
+
+Before editing code:
+
+1. Check branch and working tree.
+2. Read the focused context maps.
+3. Identify the active call path and likely inactive lookalikes.
+4. Keep the PR slice narrow.
+5. Avoid mixed-purpose commits.
+6. Do not refactor while mapping.
+7. Do not change persistence format, repeat UID semantics, sync payloads, or generated code casually.
+8. Do not revert user changes you did not make.
+9. Prefer local patterns over new abstractions.
+10. Run the smallest meaningful validation.
+
+For docs-only work:
+
+- stay on the docs branch when possible;
+- keep docs in `docs/agent-context/` unless the file is root-level onboarding like `AGENTS.md`;
+- update the numbered maps when assumptions change.
+
+For code work:
+
+- create a focused branch from the correct baseline;
+- keep generated changes intentional;
+- use `apply_patch` for manual edits;
+- run formatting only for files touched or when the project convention requires it.
+
+## Definition Of Done For Code Changes
+
+A code PR is not done until:
+
+- the active path was identified;
+- inactive/legacy-looking alternatives were not accidentally edited;
+- behavior change is described in plain language;
+- risk to persistence/sync/offline behavior is called out;
+- relevant tests, build, analyze, or smoke checks were run, or inability to run them is explicitly reported;
+- generated files are consistent when generators are involved;
+- docs are updated if a mapped assumption changed.
+
+For form/repeat/save changes, also confirm:
+
+- new submissions still save;
+- existing submissions still edit;
+- finalized/upload flow is not broken;
+- repeat rows are not silently dropped;
+- large-repeat risk was considered.
+
+## PR Slicing Rules
+
+Keep PRs boring and reviewable.
+
+Good slices:
+
+- tooling compatibility baseline;
+- docs/context maps;
+- await-save correctness fix;
+- subscription cleanup;
+- repeat UID contract implementation;
+- large-repeat measurement instrumentation;
+- one performance improvement chosen from measurement.
+
+Bad slices:
+
+- save race fix plus repeat UID persistence plus render optimization;
+- build tooling plus production behavior changes;
+- generated churn plus unrelated refactor;
+- data model migration without runtime proof;
+- docs that claim behavior without code evidence.
+
+Prefer stacked branches only when a build baseline is required and not merged yet. Once the baseline is merged, start behavior PRs from `develop`.
+
+## Known Risks Around Forms, Elements, Large Repeats, And Expressions
+
+Current known risks:
+
+- form load builds all controls and element instances eagerly;
+- repeats with 200-300 rows can create large control/model trees;
+- rule/dependency evaluation walks sections and repeat rows;
+- expression evaluation parses expressions during evaluation;
+- `FieldWidget` value subscriptions appear to need cleanup review;
+- `saveFormData()` writes one whole `formData` JSON object;
+- active save call sites have had unawaited-save risk and need a focused fix;
+- repeat UID persistence is incomplete in the current reducer;
+- generated and old form-state paths can mislead agents into editing inactive code.
+
+Current recommended order for known work:
+
+1. docs/context PRs;
+2. tooling baseline on `develop`;
+3. `fix/await-form-save`;
+4. subscription cleanup;
+5. repeat UID implementation based on `07-repeat-uid-contract.md`;
+6. measured large-repeat profiling;
+7. targeted performance PR selected by measurement.


### PR DESCRIPTION
## Summary
- add production code path map
- add active form flow map
- add config fetching/offline cache map

## Scope
Docs only. This PR intentionally excludes older code/build/package changes from party-access-model.

## Notes
pubspec/tooling compatibility changes are intentionally deferred to a separate PR after build verification from develop.