### PR TITLE
fix: await form saves before navigation

### DIFF
--- a/lib/features/form_submission/presentation/form_submission_screen.widget.dart
+++ b/lib/features/form_submission/presentation/form_submission_screen.widget.dart
@@ -123,7 +123,7 @@ class _SubmissionTabScreenState extends ConsumerState<FormTabScreen> {
         if (didPop) {
           return;
         }
-        backButtonPressed(formInstance);
+        await backButtonPressed(formInstance);
       },
       child: Scaffold(
         key: _scaffoldKey,
@@ -165,9 +165,9 @@ class _SubmissionTabScreenState extends ConsumerState<FormTabScreen> {
             child: FloatingActionButton(
               tooltip: S.of(context).saveAndCheck,
               child: getFloatIcon(),
-              onPressed: () {
+              onPressed: () async {
                 if (widget.enabled) {
-                  _saveAndShowBottomSheet(formInstance);
+                  await _saveAndShowBottomSheet(formInstance);
                 } else {
                   Navigator.pop(context);
                 }
@@ -208,7 +208,7 @@ class _SubmissionTabScreenState extends ConsumerState<FormTabScreen> {
     //     .read(formInstanceProvider(submissionId: widget.submissionId))
     //     .requireValue
     //     .saveFormData();
-    final formInstance = appLocator<FormInstance>().saveFormData();
+    await appLocator<FormInstance>().saveFormData();
   }
 
   Future<void> _showBottomSheet(FormInstance formInstance) async {

--- a/lib/features/form_submission/presentation/section/edit_row_panel.dart
+++ b/lib/features/form_submission/presentation/section/edit_row_panel.dart
@@ -117,16 +117,18 @@ class EditRowPanelState extends ConsumerState<EditRowPanel> {
             children: <Widget>[
               ReactiveValidButton(
                 color: cs.primary,
-                onPressed: () =>
-                    widget.onSave(formGroup, EditActionType.SAVE_AND_CLOSE),
+                onPressed: () {
+                  widget.onSave(formGroup, EditActionType.SAVE_AND_CLOSE);
+                },
                 label: Text(S.of(context).saveAndClose),
                 toolTip: S.of(context).saveAndClose,
                 icon: Icon(MdiIcons.contentSaveCheck),
               ),
               ReactiveValidButton(
                 label: Text(S.of(context).addNew),
-                onPressed: () => widget.onSave(
-                    formGroup, EditActionType.SAVE_AND_ADD_ANOTHER),
+                onPressed: () {
+                  widget.onSave(formGroup, EditActionType.SAVE_AND_ADD_ANOTHER);
+                },
                 icon: Icon(MdiIcons.contentSaveMove),
                 color: cs.secondary,
                 toolTip: S.of(context).addNew,

--- a/lib/features/form_submission/presentation/section/edit_row_screen.dart
+++ b/lib/features/form_submission/presentation/section/edit_row_screen.dart
@@ -16,8 +16,7 @@ import 'package:reactive_forms/reactive_forms.dart';
 
 class EditRowScreen extends ConsumerStatefulWidget {
   EditRowScreen(
-      {
-        required this.repeatInstance,
+      {required this.repeatInstance,
       required this.item,
       this.title,
       this.onRemoveItem,
@@ -134,7 +133,7 @@ class EditRowScreenState extends ConsumerState<EditRowScreen> {
                   FloatingActionButton(
                     backgroundColor: cs.primary,
                     heroTag: '${widget.item.uid}_save',
-                    onPressed: () async {
+                    onPressed: () {
                       widget.onSave(formGroup, EditActionType.SAVE_AND_CLOSE);
                     },
                     child: Icon(MdiIcons.contentSaveCheck),
@@ -142,7 +141,7 @@ class EditRowScreenState extends ConsumerState<EditRowScreen> {
                   ),
                   FloatingActionButton(
                     backgroundColor: cs.secondary,
-                    onPressed: () async {
+                    onPressed: () {
                       widget.onSave(
                           formGroup, EditActionType.SAVE_AND_ADD_ANOTHER);
                     },

--- a/lib/features/form_submission/presentation/section/repeat_table.widget.dart
+++ b/lib/features/form_submission/presentation/section/repeat_table.widget.dart
@@ -195,15 +195,18 @@ class RepeatTableState extends ConsumerState<RepeatTable> {
                     onRemoveItem: (item) {
                       _dataSource.removeItem(item);
                     },
-                    onSave: (formGroup, action) {
+                    onSave: (formGroup, action) async {
                       _repeatInstance.elementControl.markAsTouched();
-                      formInstance.saveFormData();
+                      await formInstance.saveFormData();
+                      if (!context.mounted) {
+                        return;
+                      }
                       _dataSource.updateItems(_repeatInstance.elements);
                       // repeatItem.updateValue(formGroup.value);
                       if (formGroup.valid) {
                         itemSaved = true;
-                        _handleSave(context, formInstance, _repeatInstance,
-                            repeatItem, action);
+                        await _handleSave(context, formInstance,
+                            _repeatInstance, repeatItem, action);
                       }
                     },
                   );
@@ -259,15 +262,18 @@ class RepeatTableState extends ConsumerState<RepeatTable> {
                     title: title,
                     repeatInstance: _repeatInstance,
                     item: repeatItem,
-                    onSave: (formGroup, action) {
+                    onSave: (formGroup, action) async {
                       _repeatInstance.elementControl.markAsTouched();
-                      formInstance.saveFormData();
+                      await formInstance.saveFormData();
+                      if (!context.mounted) {
+                        return;
+                      }
                       _dataSource.updateItems(_repeatInstance.elements);
                       // repeatItem.updateValue(formGroup.value);
                       if (formGroup.valid) {
                         itemSaved = true;
-                        _handleSave(context, formInstance, _repeatInstance,
-                            repeatItem, action);
+                        await _handleSave(context, formInstance,
+                            _repeatInstance, repeatItem, action);
                       }
                     },
                   ),
@@ -294,7 +300,7 @@ class RepeatTableState extends ConsumerState<RepeatTable> {
       if (action == EditActionType.SAVE_AND_ADD_ANOTHER) {
         final repeatItem = formInstance.onAddRepeatedItem(_repeatInstance);
         _dataSource.addItem(repeatItem);
-        _showEditPanel(context, formInstance, repeatItem);
+        await _showEditPanel(context, formInstance, repeatItem);
       } else if (action == EditActionType.SAVE_AND_CLOSE) {
         // Do nothing, as we've already closed the dialog
       }


### PR DESCRIPTION
## Summary
- await the main form save before showing the completion bottom sheet or handling back navigation
- await repeat-row saves before refreshing the table and closing or opening the next row editor
- keep generated route contracts unchanged; no persistence format, UID, subscription, or performance refactor in this slice

## Root cause
Some active UI paths started `saveFormData()` without awaiting the returned `Future`, then continued to navigation, row close, add-next, or scope cleanup paths. That made save completion ordering depend on timing.

## Validation
- `dart format lib/features/form_submission/presentation/form_submission_screen.widget.dart lib/features/form_submission/presentation/section/repeat_table.widget.dart lib/features/form_submission/presentation/section/edit_row_screen.dart lib/features/form_submission/presentation/section/edit_row_panel.dart`
- `flutter analyze` fails with the known baseline analyzer debt: 50 existing issues; no new type error after this patch
- `flutter test` fails with the known stale-test baseline: both discovered test files have no active `main()`
- `flutter build apk --debug` passes and builds `build/app/outputs/flutter-apk/app-debug.apk`

## Next slice
After this lands: subscription cleanup in field value listeners, then measured large-repeat reproduction before choosing a larger performance/data-shape change.