### PR TITLE
Upgrade Flutter Android tooling and release optimization

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.android.build.gradle.BaseExtension
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.gradle.api.GradleException
 import java.io.File
 import java.io.FileInputStream
@@ -31,10 +31,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
-    }
-
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId = "org.datarun.app"
@@ -59,6 +55,12 @@ android {
                 signingConfig = signingConfigs.getByName("release")
             }
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
     }
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,10 @@
-org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=1G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+android.r8.optimizedResourceShrinking=true
 #dev.steenbakker.mobile_scanner.useUnbundled=true
 #org.gradle.caching=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 dev.steenbakker.mobile_scanner.useUnbundled=true
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.9.0" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("com.android.application") version "8.13.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 
 include(":app")

--- a/lib/features/assignment/presentation/build_status.dart
+++ b/lib/features/assignment/presentation/build_status.dart
@@ -1,7 +1,6 @@
 import 'package:datarunmobile/database/shared/assignment_status.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 Widget buildStatusBadge(AssignmentStatus status,
     [double? size, ValueKey<dynamic>? key]) {
@@ -10,35 +9,35 @@ Widget buildStatusBadge(AssignmentStatus status,
 
   switch (status) {
     case AssignmentStatus.NOT_STARTED:
-      statusIcon = MdiIcons.progressClock; // More expressive icon
+      statusIcon = Icons.schedule;
       badgeColor = Colors.grey;
       break;
     case AssignmentStatus.IN_PROGRESS:
-      statusIcon = MdiIcons.circleSlice6; // More expressive icon
+      statusIcon = Icons.timelapse;
       badgeColor = Colors.blue;
       break;
     case AssignmentStatus.DONE:
-      statusIcon = MdiIcons.checkCircle; // More expressive icon
+      statusIcon = Icons.check_circle;
       badgeColor = Colors.green;
       break;
     case AssignmentStatus.RESCHEDULED:
-      statusIcon = MdiIcons.calendarArrowRight; // More expressive icon
+      statusIcon = Icons.event_repeat;
       badgeColor = Colors.orange;
       break;
     case AssignmentStatus.CANCELLED:
-      statusIcon = MdiIcons.bookCancel; // More expressive icon
+      statusIcon = Icons.cancel;
       badgeColor = Colors.red;
       break;
     case AssignmentStatus.MERGED:
-      statusIcon = MdiIcons.merge; // More expressive icon
+      statusIcon = Icons.merge_type;
       badgeColor = Colors.blueGrey;
       break;
     case AssignmentStatus.REASSIGNED:
-      statusIcon = MdiIcons.clipboardAccount; // More expressive icon
+      statusIcon = Icons.assignment_ind;
       badgeColor = Colors.deepPurpleAccent;
       break;
     default:
-      statusIcon = MdiIcons.helpCircleOutline; // More expressive icon
+      statusIcon = Icons.help_outline;
       badgeColor = Colors.black;
   }
 

--- a/lib/features/data_instance/application/table_controller.provider.g.dart
+++ b/lib/features/data_instance/application/table_controller.provider.g.dart
@@ -62,7 +62,7 @@ final class TableControllerProvider
   }
 }
 
-String _$tableControllerHash() => r'cc2f495be40e1ceb32cc328ee7feff634d73b6b9';
+String _$tableControllerHash() => r'ed28bb5aba03dbedaf2ec86dac631d272291d26b';
 
 final class TableControllerFamily extends $Family
     with

--- a/lib/features/data_instance/presentation/cell_widgets/submission_table_cell.dart
+++ b/lib/features/data_instance/presentation/cell_widgets/submission_table_cell.dart
@@ -11,7 +11,6 @@ import 'package:datarunmobile/features/form/application/map_value_to_display.dar
 import 'package:datarunmobile/features/form/presentation/widgets/value_type_value_display.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class SubmissionTableCell extends StatelessWidget {
   const SubmissionTableCell({
@@ -126,7 +125,7 @@ class SubmissionTableCell extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 key: ValueKey(fieldValue.id),
                 children: [
-                  Expanded(child: Icon(MdiIcons.barcode)),
+                  const Expanded(child: Icon(Icons.qr_code_scanner)),
                   const SizedBox(width: 4),
                   Text(fieldValue.value!.toString().substring(0, 10)),
                 ],

--- a/lib/features/form_submission/presentation/section/edit_row_screen.dart
+++ b/lib/features/form_submission/presentation/section/edit_row_screen.dart
@@ -9,7 +9,6 @@ import 'package:datarunmobile/features/form_submission/presentation/section/repe
 import 'package:datarunmobile/features/form_submission/presentation/section/section.widget.dart';
 import 'package:datarunmobile/generated/l10n.dart';
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 class EditRowScreen extends StatefulWidget {
@@ -109,7 +108,7 @@ class _EditRowScreenState extends State<EditRowScreen> {
                             dimension: 24,
                             child: CircularProgressIndicator(strokeWidth: 2),
                           )
-                        : Icon(MdiIcons.contentSaveCheck),
+                        : const Icon(Icons.save),
                     tooltip: S.of(context).saveAndClose,
                   ),
                   FloatingActionButton(
@@ -120,7 +119,7 @@ class _EditRowScreenState extends State<EditRowScreen> {
                               RepeatRowEditResult.savedAndAddAnother,
                             ),
                     heroTag: '${identityHashCode(widget.item)}_addNew',
-                    child: Icon(MdiIcons.plus),
+                    child: const Icon(Icons.add),
                     tooltip: S.of(context).addNew,
                   ),
                 ],

--- a/lib/features/form_submission/presentation/section/repeat_table_rows_source.dart
+++ b/lib/features/form_submission/presentation/section/repeat_table_rows_source.dart
@@ -10,7 +10,6 @@ import 'package:datarunmobile/features/form/presentation/widgets/value_type_valu
 import 'package:datarunmobile/features/form_submission/application/element/form_element.dart';
 import 'package:datarunmobile/generated/l10n.dart';
 import 'package:flutter/material.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class RepeatTableDataSource extends DataTableSource {
   RepeatTableDataSource(
@@ -150,7 +149,7 @@ class RepeatTableDataSource extends DataTableSource {
       case ValueType.ScannedCode:
         cellContent = Row(
           children: [
-            Icon(MdiIcons.barcode),
+            const Icon(Icons.qr_code_scanner),
             const SizedBox(width: 4),
             Text(field.value?.toString().substring(0, 10) ?? '-'),
           ],
@@ -169,7 +168,7 @@ class RepeatTableDataSource extends DataTableSource {
       case ValueType.Team:
         cellContent = Row(
           children: [
-            Icon(MdiIcons.accountGroup),
+            const Icon(Icons.groups),
             const SizedBox(width: 4),
             ValueTypeValueDisplay(
               valueType: field.template.type,

--- a/lib/features/form_submission/presentation/section/repeat_table_sliver.dart
+++ b/lib/features/form_submission/presentation/section/repeat_table_sliver.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_sticky_header/flutter_sticky_header.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class RepeatTableSliver extends HookConsumerWidget {
   const RepeatTableSliver({
@@ -36,7 +35,7 @@ class RepeatTableSliver extends HookConsumerWidget {
         color: Colors.black45,
         padding: const EdgeInsets.all(16),
         child: Row(children: [
-          Icon(MdiIcons.table),
+          const Icon(Icons.table_chart),
           Expanded(
             child: Text(repeatInstance.label, softWrap: true),
           )

--- a/lib/features/home/presentation/drawer/app_drawer_sync_item.dart
+++ b/lib/features/home/presentation/drawer/app_drawer_sync_item.dart
@@ -7,7 +7,6 @@ import 'package:datarunmobile/generated/l10n.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:stacked_services/stacked_services.dart';
 import 'package:timeago/timeago.dart' as timeago;
 
@@ -46,7 +45,7 @@ class DrawerSyncItem extends ConsumerWidget {
                 color: syncMetadataRepo.isInitialSyncDone
                     ? Colors.green
                     : Colors.red)
-            : Icon(MdiIcons.webOff, color: Colors.grey),
+            : const Icon(Icons.cloud_off, color: Colors.grey),
         onTap: isOnline
             ? () {
                 appLocator<NavigationService>().back();
@@ -64,7 +63,7 @@ class DrawerSyncItem extends ConsumerWidget {
           '$lastSynced',
           softWrap: true,
         ),
-        trailing: Icon(MdiIcons.webOff, color: Colors.grey),
+        trailing: const Icon(Icons.cloud_off, color: Colors.grey),
         onTap: null,
       ),
     );

--- a/lib/features/home/presentation/settings_view.dart
+++ b/lib/features/home/presentation/settings_view.dart
@@ -7,7 +7,6 @@ import 'package:datarunmobile/features/settings/presentation/user_settings_tab_v
 import 'package:datarunmobile/generated/l10n.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class SettingsView extends StatelessWidget {
   const SettingsView();
@@ -26,7 +25,7 @@ class SettingsView extends StatelessWidget {
                 text: S.of(context).userSettings,
               ),
               Tab(
-                icon: Icon(MdiIcons.update),
+                icon: const Icon(Icons.sync),
                 text: S.of(context).syncSettings,
               ),
               Tab(

--- a/lib/features/settings/presentation/sync_tab_view.dart
+++ b/lib/features/settings/presentation/sync_tab_view.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class SyncSettingTabView extends HookConsumerWidget {
   const SyncSettingTabView({super.key});
@@ -23,7 +22,7 @@ class SyncSettingTabView extends HookConsumerWidget {
 
         Card(
           child: ListTile(
-            leading: Icon(MdiIcons.update),
+            leading: const Icon(Icons.sync),
             title: Text(S.of(context).syncInterval),
             subtitle: DropdownButton<SyncInterval>(
               value: selectedInterval.value,

--- a/lib/features/settings/presentation/user_settings_tab_view.dart
+++ b/lib/features/settings/presentation/user_settings_tab_view.dart
@@ -6,7 +6,6 @@ import 'package:datarunmobile/core/user_session/preference.provider.dart';
 import 'package:datarunmobile/generated/l10n.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class UserSettingsTabView extends ConsumerWidget {
   const UserSettingsTabView({super.key});
@@ -24,14 +23,14 @@ class UserSettingsTabView extends ConsumerWidget {
         const SizedBox(height: 10),
         Card(
           child: ListTile(
-            leading: Icon(MdiIcons.accountArrowLeft),
+            leading: const Icon(Icons.account_circle),
             title: Text(S.of(context).loginUsername),
             subtitle: Text(currentAuthUser?.username ?? '-'),
           ),
         ),
         Card(
           child: ListTile(
-            leading: Icon(MdiIcons.faceMan),
+            leading: const Icon(Icons.person),
             title: Text(S.of(context).personInformation),
             subtitle: Text(currentAuthUser?.firstName ?? '-'),
             trailing: IconButton(
@@ -42,7 +41,7 @@ class UserSettingsTabView extends ConsumerWidget {
         ),
         Card(
           child: ListTile(
-            leading: Icon(MdiIcons.phoneSettings),
+            leading: const Icon(Icons.phone_android),
             title: Text(S.of(context).mobile),
             subtitle: Text(currentAuthUser?.mobile ?? '-'),
             trailing: IconButton(
@@ -78,7 +77,7 @@ class UserSettingsTabView extends ConsumerWidget {
         Card(
           color: Theme.of(context).colorScheme.errorContainer,
           child: ListTile(
-            leading: Icon(MdiIcons.logout,
+            leading: Icon(Icons.logout,
                 color: Theme.of(context).colorScheme.onErrorContainer),
             title: Text(
               S.of(context).logout,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,14 +28,6 @@ Future<void> main() async {
       WidgetsFlutterBinding.ensureInitialized();
       await configureDependencies();
 
-      SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle(
-        statusBarColor: Colors.transparent,
-        systemNavigationBarColor: Colors.transparent,
-        statusBarIconBrightness: Brightness.dark,
-        systemNavigationBarIconBrightness: Brightness.dark,
-        systemNavigationBarDividerColor: Colors.transparent,
-      ));
-
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
 
       FlutterError.demangleStackTrace = (StackTrace stack) {
@@ -157,8 +149,12 @@ class App extends ConsumerWidget {
         iconTheme: IconThemeData(color: barFg.withValues(alpha: 0.6)),
         actionsIconTheme: IconThemeData(color: barFg),
         surfaceTintColor: barBg,
-        systemOverlayStyle:
-            isDark ? SystemUiOverlayStyle.light : SystemUiOverlayStyle.dark,
+        systemOverlayStyle: SystemUiOverlayStyle(
+          statusBarBrightness: isDark ? Brightness.dark : Brightness.light,
+          statusBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
+          systemNavigationBarIconBrightness:
+              isDark ? Brightness.light : Brightness.dark,
+        ),
       ),
       cardTheme: CardThemeData(
         color: cs.surfaceContainerLow,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -733,22 +733,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
-  material_design_icons_flutter:
-    dependency: "direct main"
-    description:
-      name: material_design_icons_flutter
-      sha256: "6f986b7a51f3ad4c00e33c5c84e8de1bdd140489bbcdc8b66fc1283dad4dea5a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.7296"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1302,26 +1294,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   timeago:
     dependency: "direct main"
     description:
@@ -1467,5 +1459,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,6 @@ dependencies:
   injectable: ^2.5.0
   internet_connection_checker_plus: ^2.7.2
   intl: ^0.20.2
-  material_design_icons_flutter: ^7.0.7296
   mobile_scanner: ^7.0.1
   multiple_result: ^5.2.0
   package_info_plus: ^8.3.0


### PR DESCRIPTION
## Summary
- validate the app and generators on Flutter 3.44.8 / Dart 3.12.2 without a repository-local Flutter SDK pin
- replace the Flutter-3.44-incompatible `material_design_icons_flutter` package with built-in Material icons
- move Android builds to AGP 8.13.0, Gradle 8.14, and Kotlin 2.2.20
- enable optimized R8 resource shrinking and use the current Kotlin compiler DSL
- remove app-owned deprecated system-bar colors while retaining edge-to-edge mode
- reduce the Gradle heap/metaspace ceiling after the previous 8G/4G settings caused a confirmed host OOM

## Verification
- code generation completed for Stacked, Riverpod, Drift, Injectable, and Freezed
- `flutter test --no-pub`: 146 tests passed
- `flutter analyze --no-pub`: no compile errors; the existing 92 lint findings remain
- signed release AAB built as version code 51 with minSdk 24 and targetSdk 36
- release signing certificate matches the archived v6.0.0 production AAB
- optimized R8 emitted mapping/resource reports

## Notes
- The AAB upload artifact is 81.2 MB because Flutter 3.44 includes about 16 MB of compressed native `libapp.so` symbols under `BUNDLE-METADATA` for crash symbolication. That metadata is not installed on devices; the app payload is slightly smaller after removing the third-party icon font.
- The Play bitmap warning originates in AndroidX, and Flutter still contains guarded pre-Android-15 system-bar setters. This PR fixes the app-owned edge-to-edge calls and the R8 warning without forking framework code.
- Generator output still reports the repository's existing Injectable registration warning and analyzer-language warning; generation and all tests complete successfully. No unrelated generator/dependency migration is included.